### PR TITLE
Add persistentance ( fixes #18 )

### DIFF
--- a/board/pluto/post-build.sh
+++ b/board/pluto/post-build.sh
@@ -78,10 +78,12 @@ ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S10mdev ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S15watchdog ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S20urandom ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S21misc ${TARGET_DIR}/etc/init.d/
+${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S22serial ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S23udc ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S40network ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S41network ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S45msd ${TARGET_DIR}/etc/init.d/
+${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S55hostkeys ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S98autostart ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0644 ${BOARD_ROOTFS}/fw_env.config ${TARGET_DIR}/etc/
 #${INSTALL} -D -m 0644 ${BOARD_ROOTFS}/VERSIONS ${TARGET_DIR}/opt/

--- a/board/pluto/rootfs/S21misc
+++ b/board/pluto/rootfs/S21misc
@@ -18,9 +18,10 @@ case "$1" in
 	start|"")
 		echo -n "Starting miscellaneous setup: "
 		# Restore saved password and Dropbear keys
-		[[ -d /mnt/jffs2/etc ]] && cd /mnt/jffs2/etc && md5sum -s -c password.md5 && cp passwd shadow group /etc
-		[[ -d /mnt/jffs2/etc/dropbear ]] && cd /mnt/jffs2/etc/dropbear && md5sum -s -c keys.md5 && cp dropbear* /etc/dropbear/
-		[[ -d /mnt/jffs2/root/.ssh ]] && cd /mnt/jffs2/root/.ssh && md5sum -s -c keys.md5 && mkdir /root/.ssh && cp authorized_keys /root/.ssh
+		[[ -f /mnt/jffs2/dropbear_ed25519_host_key ]] && [[ ! -f /etc/dropbear/dropbear_ed25519_host_key ]] && [[ -d /etc/dropbear ]] && cp /mnt/jffs2/dropbear_ed25519_host_key /etc/dropbear/dropbear_ed25519_host_key
+		[[ ! -d /root/.ssh ]] && mkdir /root/.ssh
+		[[ -f /mnt/jffs2/authorized_keys ]] && [[ ! -f /root/.ssh/authorized_keys ]] && [[ -d /root/.ssh ]] && cp /mnt/jffs2/authorized_keys /root/.ssh/authorized_keys && chmod 600 /root/.ssh/authorized_keys
+		echo -e "#! /bin/sh\ncp /etc/dropbear/dropbear_ed25519_host_key /mnt/jffs2/dropbear_ed25519_host_key\ncp /root/.ssh/authorized_keys /mnt/jffs2/authorized_keys\n" > /root/backup-host-keys.sh && chmod u+x /root/backup-host-keys.sh
 		xo_correction
 		MAX_BS=`fw_printenv -n iio_max_block_size 2> /dev/null || echo 67108864`
 		echo ${MAX_BS} > /sys/module/industrialio_buffer_dma/parameters/max_block_size

--- a/board/pluto/rootfs/S22serial
+++ b/board/pluto/rootfs/S22serial
@@ -1,0 +1,36 @@
+#! /bin/sh
+
+case "$1" in
+	start|"")
+		echo -n "Setting serial number: "
+		SERIAL_FORCE=`fw_printenv -n serial_force 2> /dev/null || echo off`
+		SERIAL_NOR=`dmesg | grep SPI-NOR-UniqueID |  tr -cd '[a-zA-Z0-9]._-'`
+		cat /proc/mounts | grep -q mtd2 || echo "JFFS2 filesystem not mounted, use device_format_jffs2 command to setup your partition"
+		# Check or save generated serial (unique id)
+		[[ ! -f /mnt/jffs2/serial.txt ]] && dd if=/dev/urandom bs=1 count=10 2>/dev/null | base32 > /mnt/jffs2/serial.txt && echo -n "New serial number generated: `cat /mnt/jffs2/serial.txt` "
+		# Set serial number from jffs2
+		[[ -f /mnt/jffs2/serial.txt ]] && serial=`cat /mnt/jffs2/serial.txt | tr -cd '[a-zA-Z0-9]._-'` && echo -n "Serial number found in jffs2: ${serial} "
+		# Check for serial number override on sd card
+		[[ -f /mnt/sd/serial.txt ]] && serial=`cat /mnt/sd/serial.txt | tr -cd '[a-zA-Z0-9]._-'` && echo -n "Serial number override from sd: ${serial} "
+		if [ "$SERIAL_FORCE" == "off" ]; then
+		    if [ "$SERIAL_NOR" == "" ]; then
+			serial=${serial:-tezukafw}
+			echo -n "$serial" > /etc/serial
+		    else
+			serial=`echo -n "$SERIAL_NOR" | tr -cd '[a-zA-Z0-9]._-'` && echo -n "Serial number override from SPI-NOR-UniqueID: ${serial} "
+		    fi
+		else
+			serial=`echo -n "$SERIAL_FORCE" | tr -cd '[a-zA-Z0-9]._-'` && echo -n "Serial number override from env serial_force : ${serial} "
+		fi
+		[[ "${serial}" == "tezukafw" ]] && echo "Something went wrong, serial set 'tezukafw' "
+		echo -n "$serial" > /etc/serial
+		[ $? = 0 ] && echo "OK" || echo "FAIL"
+		;;
+	stop)
+
+		;;
+	*)
+		echo "Usage: $0 {start|stop}" >&2
+		exit 1
+		;;
+esac

--- a/board/pluto/rootfs/S22serial
+++ b/board/pluto/rootfs/S22serial
@@ -15,7 +15,6 @@ case "$1" in
 		if [ "$SERIAL_FORCE" == "off" ]; then
 		    if [ "$SERIAL_NOR" == "" ]; then
 			serial=${serial:-tezukafw}
-			echo -n "$serial" > /etc/serial
 		    else
 			serial=`echo -n "$SERIAL_NOR" | tr -cd '[a-zA-Z0-9]._-'` && echo -n "Serial number override from SPI-NOR-UniqueID: ${serial} "
 		    fi

--- a/board/pluto/rootfs/S23udc
+++ b/board/pluto/rootfs/S23udc
@@ -5,12 +5,15 @@ source /etc/device_config
 CONFIGFS=/sys/kernel/config/usb_gadget
 GADGET=$CONFIGFS/composite_gadget
 IIOD_OPTS="-D -n $ENDPOINTS -F /dev/iio_ffs"
-UDC_HANDLE_SUSPEND=`fw_printenv -n udc_handle_suspend 2> /dev/null || echo 0`
-USB_ETH_MODE=`fw_printenv -n usb_ethernet_mode 2> /dev/null || echo rndis`
-AUDIO_MODE=`fw_printenv -n audio_mode 2> /dev/null || echo off`
-NB_CORE=`nproc 2> /dev/null || 1` 
-SERIAL_FORCE=`fw_printenv -n serial_force 2> /dev/null || echo off`
-FORCE_MODEL=`fw_printenv -n force_model 2> /dev/null || echo off`
+UDC_HANDLE_SUSPEND=`fw_printenv -n udc_handle_suspend 2> /dev/null || echo 0 | tr -cd '[a-zA-Z0-9]._-'`
+USB_ETH_MODE=`fw_printenv -n usb_ethernet_mode 2> /dev/null || echo rndis | tr -cd '[a-zA-Z0-9]._-'`
+AUDIO_MODE=`fw_printenv -n audio_mode 2> /dev/null || echo off | tr -cd '[a-zA-Z0-9]._-'`
+NB_CORE=`nproc 2> /dev/null || 1`
+#serial should be set in /etc/serial
+ETCSERIAL=`cat /etc/serial | tr -cd '[a-zA-Z0-9]._-'`
+[[ "$ETCSERIAL" == "" ]] && ETCSERIAL="tezukafw" && echo -n "Serial missing in /etc/serial. Using serial: tezukafw "
+FORCE_MODEL=`fw_printenv -n force_model 2> /dev/null || echo off | tr -cd '[a-zA-Z0-9]._-'`
+DISABLE_CONSOLE=`fw_printenv -n disable_gadget_console 2> /dev/null || echo off | tr -cd '[a-zA-Z0-9]._-'`
 if [ "$USB_ETH_MODE" == "ncm" ]
 then
 	USB_NET_FUNCTION=ncm.usb0
@@ -78,18 +81,10 @@ case "$1" in
 		model_variant=2
 	fi	
 
-	if [ "$SERIAL_FORCE" == "off" ]; then
-
-	serial=`dmesg | grep SPI-NOR-UniqueID`
-	serial=${serial#*SPI-NOR-UniqueID }
-
-	else
-		serial="$SERIAL_FORCE"
-	fi
+	serial=${ETCSERIAL}
 
 	create_iiod_context_attributes "$model" "$serial" "$model_variant"
 
-	echo $serial > /etc/serial
 	sha1=`echo $serial | sha1sum`
 
 	echo 0x0456 > $GADGET/idVendor
@@ -176,6 +171,13 @@ if [ "$AUDIO_MODE" == "on" ]
 	sleep 0.2
 
 	echo ci_hdrc.0 > $GADGET/UDC
+
+	if [ "$DISABLE_CONSOLE" == "off" ]
+	    then
+		GS_PORT_NUMBER=`cat $GADGET/configs/c.1/acm.usb0/port_num`
+		GS_PORT_DEVICE="ttyGS${GS_PORT_NUMBER}"
+		grep -q ^${GS_PORT_DEVICE} /etc/inittab || ( echo "${GS_PORT_DEVICE}::respawn:/sbin/getty -L ${GS_PORT_DEVICE} 0 vt100 # USB_GADGET_SERIAL_CONSOLE" >> /etc/inittab && kill -1 1 )
+	fi
 	
 	[ $? = 0 ] && echo "OK" || echo "FAIL"
 

--- a/board/pluto/rootfs/S40network
+++ b/board/pluto/rootfs/S40network
@@ -15,38 +15,42 @@ create_system_files () {
 	CONF=/opt/config.txt
 	IFAC=/etc/network/interfaces
 	HOSTAPD=/etc/hostapd.conf
-	HOSTNAME=`fw_printenv -n hostname 2> /dev/null || cat /etc/hostname`
+	HOSTNAME=`fw_printenv -n hostname 2> /dev/null || cat /etc/hostname | tr -cd '[a-zA-Z0-9]._-'`
 	echo $HOSTNAME > /etc/hostname
+	SERIAL=`cat /etc/serial | tr -cd '[a-zA-Z0-9]._-'`
+	[[ "$SERIAL" == "" ]] && SERIAL="tezukafw" && echo -n "Serial missing in /etc/serial. Using serial for eth0 mac: tezukafw "
 
-	IPADDR=`fw_printenv -n ipaddr 2> /dev/null || echo 192.168.2.1`
-	IPADDR_HOST=`fw_printenv -n ipaddr_host 2> /dev/null || echo 192.168.2.10`
-	NETMASK=`fw_printenv -n netmask 2> /dev/null || echo 255.255.255.0`
+	IPADDR=`fw_printenv -n ipaddr 2> /dev/null || echo 192.168.2.1 | tr -cd '[a-zA-Z0-9]._-'`
+	IPADDR_HOST=`fw_printenv -n ipaddr_host 2> /dev/null || echo 192.168.2.10 | tr -cd '[a-zA-Z0-9]._-'`
+	NETMASK=`fw_printenv -n netmask 2> /dev/null || echo 255.255.255.0 | tr -cd '[a-zA-Z0-9]._-'`
 
-	ETH_IPADDR=`fw_printenv -n ipaddr_eth 2> /dev/null`
-	ETH_NETMASK=`fw_printenv -n netmask_eth 2> /dev/null || echo 255.255.255.0`
-	ETH_GW=`fw_printenv -n gateway_eth 2> /dev/null` 
+	ETH_IPADDR=`fw_printenv -n ipaddr_eth 2> /dev/null | tr -cd '[a-zA-Z0-9]._-'`
+	ETH_NETMASK=`fw_printenv -n netmask_eth 2> /dev/null || echo 255.255.255.0 | tr -cd '[a-zA-Z0-9]._-'`
+	ETH_GW=`fw_printenv -n gateway_eth 2> /dev/null | tr -cd '[a-zA-Z0-9]._-'`
+	sha1=`echo ${SERIAL} | sha1sum`
+	ETH_MAC=`echo -n 00:60:88; echo $sha1 | dd bs=1 count=6 2>/dev/null | hexdump -v -e '/1 ":%01c""%c"'`
 
-	WLAN_SSID=`fw_printenv -n ssid_wlan 2> /dev/null`
-	WLAN_PWD=`fw_printenv -n pwd_wlan 2> /dev/null`
-	WLAN_IPADDR=`fw_printenv -n ipaddr_wlan 2> /dev/null`
+	WLAN_SSID=`fw_printenv -n ssid_wlan 2> /dev/null | tr -cd '[a-zA-Z0-9]._-'`
+	WLAN_PWD=`fw_printenv -n pwd_wlan 2> /dev/null | tr -cd '[a-zA-Z0-9]._-'`
+	WLAN_IPADDR=`fw_printenv -n ipaddr_wlan 2> /dev/null | tr -cd '[a-zA-Z0-9]._-'`
 
-	XO_CORRECTION=`fw_printenv -n xo_correction 2> /dev/null`
-	UDC_HANDLE_SUSPEND=`fw_printenv -n udc_handle_suspend 2> /dev/null || echo 0`
-	USB_ETH_MODE=`fw_printenv -n usb_ethernet_mode 2> /dev/null || echo rndis`
-	LNB_POWER=`fw_printenv -n lnb_power 2> /dev/null || echo off`
-	REFCLK_SOURCE=`fw_printenv -n refclk_source 2>/dev/null || echo internal`
-	MAXCPUS=`fw_printenv -n maxcpus 2> /dev/null || echo 2`
-	ATTR_NAME=`fw_printenv -n attr_name 2> /dev/null || echo compatible`
-	ATTR_VAL=`fw_printenv -n attr_val 2> /dev/null || echo ad9361`
-	MODE=`fw_printenv -n mode 2> /dev/null || echo 1r1t`
-	AUDIO_MODE=`fw_printenv -n audio_mode 2> /dev/null || echo off`
-	RF_INPUT=`fw_printenv -n rf_input 2> /dev/null || echo rx1`
-	RF_OUTPUT=`fw_printenv -n rf_output 2> /dev/null || echo tx1`
-	SERIAL_FORCE=`fw_printenv -n serial_force 2> /dev/null || echo off`
-	CALLSIGN=`fw_printenv -n callsign 2> /dev/null || echo NOCALL`
-	LOCATOR=`fw_printenv -n locator 2> /dev/null || echo NOLOCATOR`
-	NFS_SERVER=`fw_printenv -n nfs_server 2> /dev/null`
-	FORCE_MODEL=`fw_printenv -n force_model 2> /dev/null || echo off`
+	XO_CORRECTION=`fw_printenv -n xo_correction 2> /dev/null | tr -cd '[a-zA-Z0-9]._-'`
+	UDC_HANDLE_SUSPEND=`fw_printenv -n udc_handle_suspend 2> /dev/null || echo 0 | tr -cd '[a-zA-Z0-9]._-'`
+	USB_ETH_MODE=`fw_printenv -n usb_ethernet_mode 2> /dev/null || echo rndis | tr -cd '[a-zA-Z0-9]._-'`
+	LNB_POWER=`fw_printenv -n lnb_power 2> /dev/null || echo off | tr -cd '[a-zA-Z0-9]._-'`
+	REFCLK_SOURCE=`fw_printenv -n refclk_source 2>/dev/null || echo internal | tr -cd '[a-zA-Z0-9]._-'`
+	MAXCPUS=`fw_printenv -n maxcpus 2> /dev/null || echo 2 | tr -cd '[a-zA-Z0-9]._-'`
+	ATTR_NAME=`fw_printenv -n attr_name 2> /dev/null || echo compatible | tr -cd '[a-zA-Z0-9]._-'`
+	ATTR_VAL=`fw_printenv -n attr_val 2> /dev/null || echo ad9361 | tr -cd '[a-zA-Z0-9]._-'`
+	MODE=`fw_printenv -n mode 2> /dev/null || echo 1r1t | tr -cd '[a-zA-Z0-9]._-'`
+	AUDIO_MODE=`fw_printenv -n audio_mode 2> /dev/null || echo off | tr -cd '[a-zA-Z0-9]._-'`
+	RF_INPUT=`fw_printenv -n rf_input 2> /dev/null || echo rx1 | tr -cd '[a-zA-Z0-9]._-'`
+	RF_OUTPUT=`fw_printenv -n rf_output 2> /dev/null || echo tx1 | tr -cd '[a-zA-Z0-9]._-'`
+	SERIAL_FORCE=`fw_printenv -n serial_force 2> /dev/null || echo off | tr -cd '[a-zA-Z0-9]._-'`
+	CALLSIGN=`fw_printenv -n callsign 2> /dev/null || echo NOCALL | tr -cd '[a-zA-Z0-9]._-'`
+	LOCATOR=`fw_printenv -n locator 2> /dev/null || echo NOLOCATOR | tr -cd '[a-zA-Z0-9]._-'`
+	NFS_SERVER=`fw_printenv -n nfs_server 2> /dev/null | tr -cd '[a-zA-Z0-9]._-'`
+	FORCE_MODEL=`fw_printenv -n force_model 2> /dev/null || echo off | tr -cd '[a-zA-Z0-9]._-'`
 
 	### /etc/udhcpd.conf ###
 	echo "start $IPADDR_HOST" > $UDHCPD_CONF
@@ -78,18 +82,17 @@ create_system_files () {
 	if [ -n "$ETH_IPADDR" ]
 	then
 		if [ "$ETH_IPADDR" == "AP" ]; then
-			echo -e "iface eth0 inet static\n" >>$IFAC
-			echo -e "address 192.168.4.1\n" >>$IFAC
-			echo -e "netmask 255.255.255.0\n" >>$IFAC
+			echo -e "iface eth0 inet static\n\taddress 192.168.4.1\n\tnetmask 255.255.255.0" >>$IFAC
 		else
-			echo -e "iface eth0 inet static" >> $IFAC
-			echo -e "\taddress $ETH_IPADDR\n""\tnetmask $ETH_NETMASK\n" >> $IFAC
+			echo -e "iface eth0 inet static\n\taddress $ETH_IPADDR\n\tnetmask $ETH_NETMASK" >> $IFAC
 			if [ -n "$ETH_GW" ]; then
-				echo -e "\tgateway $ETH_GW\n" >> $IFAC
-			fi	
+				echo -e "\tgateway $ETH_GW" >> $IFAC
+			fi
 		fi	
+		echo -e "\thwaddress ether $ETH_MAC\n" >> $IFAC
 	else
-		echo -e "iface eth0 inet dhcp\n" >> $IFAC
+		echo -e "iface eth0 inet dhcp" >> $IFAC
+		echo -e "\thwaddress ether $ETH_MAC\n" >> $IFAC
 	fi
 
 	### /etc/wpa.conf ###
@@ -97,10 +100,10 @@ create_system_files () {
 	then
         if [ "$WLAN_SSID" == "AP" ]; then
     # We are in access point mode
-        echo -e "auto wlan0\n" >> $IFAC
-        echo -e "iface wlan0 inet static\n" >>$IFAC
-        echo -e "address 192.168.3.1\n" >>$IFAC
-        echo -e "netmask 255.255.255.0\n" >>$IFAC
+        echo -e "auto wlan0" >> $IFAC
+        echo -e "\tiface wlan0 inet static" >>$IFAC
+        echo -e "\taddress 192.168.3.1" >>$IFAC
+        echo -e "\tnetmask 255.255.255.0" >>$IFAC
 
 		#Make hostapd
 		echo -e "interface=wlan0\n" > $HOSTAPD
@@ -196,7 +199,7 @@ create_system_files () {
 	echo ""$'\r'>> $CONF
 	### /www/index.html ###
 
-	sed -i -e "s/#IP#/$IPADDR/g" -e "s/#HOSTIP#/$IPADDR_HOST/g" -e "s/#NETMASK#/$NETMASK/g" -e "s/#HOSTNAME#/$HOSTNAME/g" -e "s/#SSID_WLAN#/$WLAN_SSID/g" -e "s/#IPADDR_WLAN#/$WLAN_IPADDR/g" -e "s/#IPADDR_ETH#/$ETH_IPADDR/g" -e "s/#NETMASK_ETH#/$ETH_NETMASK/g" /www/index.html
+	sed -i -e "s/#IP#/$IPADDR/g" -e "s/#HOSTIP#/$IPADDR_HOST/g" -e "s/#NETMASK#/$NETMASK/g" -e "s/#HOSTNAME#/$HOSTNAME/g" -e "s/#SSID_WLAN#/$WLAN_SSID/g" -e "s/#IPADDR_WLAN#/$WLAN_IPADDR/g" -e "s/#IPADDR_ETH#/$ETH_IPADDR/g" -e "s/#NETMASK_ETH#/$ETH_NETMASK/g" -e "s/#GW_ETH#/$ETH_GW/g" -e "s/#MAC_ETH#/$ETH_MAC/g" /www/index.html
 
 	}
 

--- a/board/pluto/rootfs/S55hostkeys
+++ b/board/pluto/rootfs/S55hostkeys
@@ -7,14 +7,14 @@ case "$1" in
 		# Save  Dropbear keys
 		[[ ! -f /mnt/jffs2/dropbear_ed25519_host_key ]] && [[ -f /etc/dropbear/dropbear_ed25519_host_key ]] && [[ -d /mnt/jffs2 ]] && cp /etc/dropbear/dropbear_ed25519_host_key /mnt/jffs2/dropbear_ed25519_host_key
 		# Save ssh authorized keys
-		[[ ! -f /mnt/jffs2/authorized_keys ]] && [[ -f /root/.ssh/authorized_keys ]] && [[ -d /mnt/jffs2 ]] && cp  /root/.ssh/authorized_keys && chmod 600 /root/.ssh/authorized_keys /mnt/jffs2/authorized_keys
+		[[ ! -f /mnt/jffs2/authorized_keys ]] && [[ -f /root/.ssh/authorized_keys ]] && [[ -d /mnt/jffs2 ]] && cp /root/.ssh/authorized_keys /mnt/jffs2/authorized_keys
 		;;
 	stop)
 		echo -n "Starting host keys backup: "
 		# Save  Dropbear keys
 		[[ ! -f /mnt/jffs2/dropbear_ed25519_host_key ]] && [[ -f /etc/dropbear/dropbear_ed25519_host_key ]] && [[ -d /mnt/jffs2 ]] && cp /etc/dropbear/dropbear_ed25519_host_key /mnt/jffs2/dropbear_ed25519_host_key
 		# Save ssh authorized keys
-		[[ ! -f /mnt/jffs2/authorized_keys ]] && [[ -f /root/.ssh/authorized_keys ]] && [[ -d /mnt/jffs2 ]] && cp  /root/.ssh/authorized_keys /mnt/jffs2/authorized_keys
+		[[ ! -f /mnt/jffs2/authorized_keys ]] && [[ -f /root/.ssh/authorized_keys ]] && [[ -d /mnt/jffs2 ]] && cp /root/.ssh/authorized_keys /mnt/jffs2/authorized_keys
 		;;
 	*)
 		echo "Usage: $0 {start|stop}" >&2

--- a/board/pluto/rootfs/S55hostkeys
+++ b/board/pluto/rootfs/S55hostkeys
@@ -1,0 +1,23 @@
+#! /bin/sh
+
+
+case "$1" in
+	start|"")
+		echo -n "Starting host keys backup: "
+		# Save  Dropbear keys
+		[[ ! -f /mnt/jffs2/dropbear_ed25519_host_key ]] && [[ -f /etc/dropbear/dropbear_ed25519_host_key ]] && [[ -d /mnt/jffs2 ]] && cp /etc/dropbear/dropbear_ed25519_host_key /mnt/jffs2/dropbear_ed25519_host_key
+		# Save ssh authorized keys
+		[[ ! -f /mnt/jffs2/authorized_keys ]] && [[ -f /root/.ssh/authorized_keys ]] && [[ -d /mnt/jffs2 ]] && cp  /root/.ssh/authorized_keys && chmod 600 /root/.ssh/authorized_keys /mnt/jffs2/authorized_keys
+		;;
+	stop)
+		echo -n "Starting host keys backup: "
+		# Save  Dropbear keys
+		[[ ! -f /mnt/jffs2/dropbear_ed25519_host_key ]] && [[ -f /etc/dropbear/dropbear_ed25519_host_key ]] && [[ -d /mnt/jffs2 ]] && cp /etc/dropbear/dropbear_ed25519_host_key /mnt/jffs2/dropbear_ed25519_host_key
+		# Save ssh authorized keys
+		[[ ! -f /mnt/jffs2/authorized_keys ]] && [[ -f /root/.ssh/authorized_keys ]] && [[ -d /mnt/jffs2 ]] && cp  /root/.ssh/authorized_keys /mnt/jffs2/authorized_keys
+		;;
+	*)
+		echo "Usage: $0 {start|stop}" >&2
+		exit 1
+		;;
+esac

--- a/board/pluto/rootfs/index.html
+++ b/board/pluto/rootfs/index.html
@@ -315,6 +315,14 @@ for interacting with the PlutoSDR from your favorite shell.
 <td>Netmask</td>
 <td>#NETMASK_ETH#</td>
 </tr>
+<tr>
+<td>Default gateway (Ethernet)</td>
+<td>#GW_ETH#</td>
+</tr>
+<tr>
+<td>MAC Address (Ethenet)</td>
+<td>#MAC_ETH#</td>
+</tr>
 </tbody>
 </table>
 

--- a/board/pluto/rootfs/install.sh
+++ b/board/pluto/rootfs/install.sh
@@ -15,10 +15,12 @@ ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S10mdev ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S15watchdog ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S20urandom ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S21misc ${TARGET_DIR}/etc/init.d/
+${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S22serial ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S23udc ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S40network ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S41network ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S45msd ${TARGET_DIR}/etc/init.d/
+${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S55hostkeys ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0755 ${BOARD_ROOTFS}/S98autostart ${TARGET_DIR}/etc/init.d/
 ${INSTALL} -D -m 0644 ${BOARD_ROOTFS}/fw_env.config ${TARGET_DIR}/etc/
 ${INSTALL} -D -m 0644 ${BOARD_ROOTFS}/VERSIONS ${TARGET_DIR}/opt/


### PR DESCRIPTION
Generation of mac address by hand can lead to errors. I have extended generation and persistence of serial number (in jffs2, from syslog, from sd card, from fw_env), and serial number is used to generate sha256 hash to derive 3 last octets of mac address.
Also added fixes that will store dropbear host key, and, if needed, ssh authorized_keys in jffs2 and restore them on power on.
In this way device can boot with predictable mac address, predictable ip and persistent host key.

In case of first boot with no serial or keys present, they will be generated and stored in jffs2.
