### PR TITLE
Include Overclock Files in LibreSDR.zip

### DIFF
--- a/board/libre/post_image-uboot.sh
+++ b/board/libre/post_image-uboot.sh
@@ -56,4 +56,4 @@ cp $BIN_DIR/pluto.dfu $SDIMGDIR/uImage
 cp $BIN_DIR/zynq-libre.dtb $SDIMGDIR/devicetree.dtb
 cp $BOARD_DIR/uboot-env.txt $SDIMGDIR/uEnv.txt
 
-cd $BIN_DIR && zip tezuka.zip boot.dfu boot.frm pluto.frm pluto.dfu sdimg/*
+cd $BIN_DIR && zip tezuka.zip boot.dfu boot.frm pluto.frm pluto.dfu sdimg/* sdimg/overclock/*


### PR DESCRIPTION
During the implementation of changing the overclock for the LibreSDR the zip command was not properly adjusted,resulting in release files not including files in the overclock directory but including the directory itself. This should fix this issue and make it more user friendly to overclock.