### PR TITLE
Fix signs for time sync

### DIFF
--- a/board/pluto/overlay_maia/root/adj_chrony.sh
+++ b/board/pluto/overlay_maia/root/adj_chrony.sh
@@ -10,9 +10,9 @@ sign_correction=$(chronyc tracking | grep Frequency | cut -d ":" -f 2 | cut -d "
 
 echo "High accurate ppm = $ppm +/- $precision $sign_correction"
 if [ "$sign_correction" = "fast" ] ; then
-    xo=$(printf "%.0f" $(echo "scale=25; 40000000*(1-($ppm)/1000000)" | bc))
-else
     xo=$(printf "%.0f" $(echo "scale=25; 40000000*(1+($ppm)/1000000)" | bc))
+else
+    xo=$(printf "%.0f" $(echo "scale=25; 40000000*(1-($ppm)/1000000)" | bc))
 fi        
 echo "Correct $xo"
 echo $xo > /sys/bus/iio/devices/iio:device0/xo_correction


### PR DESCRIPTION
The initial commit confused correction in ppm with what xo_correction. Based on this post by an Analog employee https://ez.analog.com/linux-software-drivers/f/q-a/539037/ad9363-xo_correction-precision/399563 the xo_correction value is the true clock frequency in hz, thus if its fast by x ppm it means its xo_freq*(1+ppm). Similar is true for being slow. This pr should fix this. 
