### PR TITLE
Bump buildroot version in getbuildroot.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,13 @@ If you like this firmware you can help me maintaining it by
 ```
 git clone https://github.com/F5OEO/tezuka_fw
 cd tezuka_fw
-wget https://buildroot.org/downloads/buildroot-2024.11.1.tar.gz
+bash getbuildroot.sh
 
-tar -xvf buildroot-2024.11.1.tar.gz
 ```
 ### Build
 ```
 source sourceme.first
-cd buildroot-2024.11.1
+cd buildroot
 make pluto_maiasdr_defconfig && make
 ```
 ### Result

--- a/getbuildroot.sh
+++ b/getbuildroot.sh
@@ -1,1 +1,2 @@
-mkdir -p buildroot && wget -O- https://buildroot.org/downloads/buildroot-2024.11.1.tar.gz | tar -xz -C buildroot --strip-component 1
+#!/usr/bin/env bash
+wget -O- https://buildroot.org/downloads/buildroot-2024.11.1.tar.gz | tar -xz --one-top-level=buildroot --strip-components=1

--- a/getbuildroot.sh
+++ b/getbuildroot.sh
@@ -1,2 +1,1 @@
-wget https://buildroot.org/downloads/buildroot-2024.08.tar.gz
-tar -xvf buildroot-2024.08.tar.gz
+mkdir -p buildroot && wget -O- https://buildroot.org/downloads/buildroot-2024.11.1.tar.gz | tar -xz -C buildroot --strip-component 1


### PR DESCRIPTION
Using version 2024.11.1 like in README. Also
the new script does not save the downloaded archive. Just extracts the archive into buildroot dir.

The instruction in README now uses getbuildroot.sh instead of raw wget + tar.