### PR TITLE
board/pluto: Use full inittab file instead of sed patches

### DIFF
--- a/board/pluto/overlay_base/etc/inittab
+++ b/board/pluto/overlay_base/etc/inittab
@@ -1,0 +1,45 @@
+# /etc/inittab
+#
+# Copyright (C) 2001 Erik Andersen <andersen@codepoet.org>
+#
+# Note: BusyBox init doesn't support runlevels.  The runlevels field is
+# completely ignored by BusyBox init. If you want runlevels, use
+# sysvinit.
+#
+# Format for each entry: <id>:<runlevels>:<action>:<process>
+#
+# id        == tty to run on, or empty for /dev/console
+# runlevels == ignored
+# action    == one of sysinit, respawn, askfirst, wait, and once
+# process   == program to run
+
+# Startup the system
+::sysinit:/bin/mount -t proc proc /proc
+::sysinit:/bin/mount -o remount,rw /
+::sysinit:/bin/mkdir -p /dev/pts /dev/shm
+::sysinit:/bin/mount -a
+::sysinit:/bin/mkdir -p /run/lock/subsys
+::sysinit:/sbin/swapon -a
+null::sysinit:/bin/ln -sf /proc/self/fd /dev/fd
+null::sysinit:/bin/ln -sf /proc/self/fd/0 /dev/stdin
+null::sysinit:/bin/ln -sf /proc/self/fd/1 /dev/stdout
+null::sysinit:/bin/ln -sf /proc/self/fd/2 /dev/stderr
+::sysinit:/bin/mount -t debugfs none /sys/kernel/debug/
+::sysinit:/bin/hostname -F /etc/hostname
+# now run any rc scripts
+::sysinit:/etc/init.d/rcS
+
+# Put a getty on the serial port
+ttyPS0::respawn:/sbin/getty -L  ttyPS0 0 vt100 # GENERIC_SERIAL
+# ttyGS0 is not relevant and persistant on u-boot. As ACM seems to allows
+# ONLY one serial, let use it as a general Serial link Rev C has a 2nd tty
+# port plugged on usb power to have a full control
+ttyGS0::respawn:/sbin/getty -L ttyGS0 0 vt100 # USB console
+
+# Stuff to do for the 3-finger salute
+#::ctrlaltdel:/sbin/reboot
+
+# Stuff to do before rebooting
+::shutdown:/etc/init.d/rcK
+::shutdown:/sbin/swapoff -a
+::shutdown:/bin/umount -a -r

--- a/board/pluto/post-build.sh
+++ b/board/pluto/post-build.sh
@@ -5,20 +5,6 @@ set -e
 
 BOARD_DIR=$(dirname ${0})
 
-# Add a console on tty1
-grep -qE '^ttyGS0::' ${TARGET_DIR}/etc/inittab || \
-sed -i '/GENERIC_SERIAL/a\
-ttyGS0::respawn:/sbin/getty -L ttyGS0 0 vt100 # USB console' ${TARGET_DIR}/etc/inittab
-
-#ttyGS0 is not relevant and persistant on u-boot. As ACM seems to allows ONLY one serial, let use it as a general Serial link
-#Rev C has a 2nd tty port plugged on usb power to have a full control
-
-grep -qE '^::sysinit:/bin/mount -t debugfs' ${TARGET_DIR}/etc/inittab || \
-sed -i '/hostname/a\
-::sysinit:/bin/mount -t debugfs none /sys/kernel/debug/' ${TARGET_DIR}/etc/inittab
-
-sed -i -e '/::sysinit:\/bin\/hostname -F \/etc\/hostname/d' ${TARGET_DIR}/etc/inittab
-
 grep -q mtd2 ${TARGET_DIR}/etc/fstab || echo "mtd2 /mnt/jffs2 jffs2 rw,noatime 0 0" >> ${TARGET_DIR}/etc/fstab
 
 # Prepare LICENSE.html


### PR DESCRIPTION
A full initab file makes it easier to see what happens when the system starts. It will also be easier to change inittab in the future.