### PR TITLE
Update S40network WLAN to allow special characters.

### DIFF
--- a/board/tezuka/common/overlay_base/etc/init.d/S40network
+++ b/board/tezuka/common/overlay_base/etc/init.d/S40network
@@ -30,8 +30,8 @@ create_system_files () {
 	sha1=`echo ${SERIAL} | sha1sum`
 	ETH_MAC=`echo -n 00:60:88; echo $sha1 | dd bs=1 count=6 2>/dev/null | hexdump -v -e '/1 ":%01c""%c"'`
 
-	WLAN_SSID=`fw_printenv -n ssid_wlan 2> /dev/null | tr -cd '[a-zA-Z0-9 \\/]._-'`
-	WLAN_PWD=`fw_printenv -n pwd_wlan 2> /dev/null | tr -cd '[a-zA-Z0-9]._-'`
+	WLAN_SSID=`fw_printenv -n ssid_wlan 2> /dev/null | tr -cd '[:print:]'`
+	WLAN_PWD=`fw_printenv -n pwd_wlan 2> /dev/null | tr -cd '[:print:]'`
 	WLAN_IPADDR=`fw_printenv -n ipaddr_wlan 2> /dev/null | tr -cd '[a-zA-Z0-9]._-'`
 
 	XO_CORRECTION=`fw_printenv -n xo_correction 2> /dev/null | tr -cd '[a-zA-Z0-9]._-'`


### PR DESCRIPTION
A lot of wireless access points use special characters nowadays in both the SSID and password (including mine ;-) ). While the original code allowed for some special characters, in my case the @ sign was not. I propose these changes to support broader range of special characters in these cases while still protecting from rogue characters like carriage returns and null bytes.