### PR TITLE
build: bump rust-wasm 1.86 -> 1.88

### DIFF
--- a/package/rust-wasm/rust-wasm.mk
+++ b/package/rust-wasm/rust-wasm.mk
@@ -6,6 +6,7 @@
 
 # When updating this version, check whether support/download/cargo-post-process
 # still generates the same archives.
+# Must match Buildroot's host-rustc version (check with host/bin/rustc --version)
 RUST_WASM_VERSION = 1.88.0
 RUST_WASM_SITE = https://static.rust-lang.org/dist
 RUST_WASM_LICENSE = Apache-2.0 or MIT


### PR DESCRIPTION
Buildroot 2026.02 ships host rustc 1.88.0; the wasm32-unknown-unknown std library must match the host version or wasm-loading packages (maia-wasm) fail to build.

- `package/rust-wasm/rust-wasm.mk`: `RUST_WASM_VERSION` 1.86.0 -> 1.88.0

Matrix CI: 12/12 boards build green.
