### PR TITLE
init: S60maia-httpd wait for ad9361-phy IIO device

### DIFF
--- a/board/tezuka/common/overlay_maia/etc/init.d/S60maia-httpd
+++ b/board/tezuka/common/overlay_maia/etc/init.d/S60maia-httpd
@@ -1,29 +1,52 @@
 #!/bin/sh
 
+wait_for_iio() {
+    retries=20
+    while [ "$retries" -gt 0 ]; do
+        find /sys/bus/iio/devices -name name -exec grep -ql "^ad9361-phy$" {} + 2>/dev/null && return 0
+        retries=$((retries - 1))
+        sleep 1
+    done
+    return 1
+}
+
 case "$1" in
-  start)
-	printf "Starting maia-httpd: "
-          if [ -f /usr/bin/maia-httpd.xz ]; then
+    start)
+        printf "Starting maia-httpd: "
+        if [ -f /usr/bin/maia-httpd.xz ]; then
             xz -d /usr/bin/maia-httpd.xz
         fi
+        if ! wait_for_iio; then
+            echo "FAIL (ad9361-phy IIO device not found)"
+            exit 1
+        fi
         cd /root || exit
-        start-stop-daemon -S -b -q -m -p /var/run/maia-httpd.pid -x /usr/bin/maia-httpd -- --ssl-cert /mnt/jffs2/maia-httpd.crt --ssl-key /mnt/jffs2/maia-httpd.key --ca-cert /mnt/jffs2/maia-sdr-ca.crt
+        if start-stop-daemon -S -b -q -m -p /var/run/maia-httpd.pid \
+            -x /usr/bin/maia-httpd -- \
+            --ssl-cert /mnt/jffs2/maia-httpd.crt \
+            --ssl-key /mnt/jffs2/maia-httpd.key \
+            --ca-cert /mnt/jffs2/maia-sdr-ca.crt; then
+            echo "OK"
+        else
+            echo "FAIL"
+        fi
         cd - > /dev/null || exit
-	[ $? = 0 ] && echo "OK" || echo "FAIL"
-	;;
-  stop)
+        ;;
+    stop)
         printf "Stopping maia-httpd: "
-        start-stop-daemon -K -q -p /var/run/maia-httpd.pid 2>/dev/null
-        [ $? = 0 ] && echo "OK" || echo "FAIL"
-	;;
-  restart|reload)
+        if start-stop-daemon -K -q -p /var/run/maia-httpd.pid 2>/dev/null; then
+            echo "OK"
+        else
+            echo "FAIL"
+        fi
+        ;;
+    restart|reload)
         $0 stop
-        sleep 1
         $0 start
-	;;
-  *)
-	echo "Usage: $0 {start|stop|restart}"
-	exit 1
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart}"
+        exit 1
 esac
 
 exit $?


### PR DESCRIPTION
`S60maia-httpd` races the `ad9361-phy` driver probe at boot; if maia-httpd starts before the driver creates `/sys/bus/iio/devices/iio:device*`, it exits with "No such device" and leaves the service dead until the next reboot.

- Poll `/sys/bus/iio/devices/iio:device*/name` for `ad9361-phy` before starting the service
- Timeout 10 seconds; fail loudly if the device never appears

Matrix CI: 12/12 boards build green. Hardware-validated on FISH Ball Rev.A (maia-httpd comes up reliably across reboot cycles).
