### PR TITLE
init: fix gpsd/iiod/input-event-daemon boot warnings

### DIFF
--- a/board/tezuka/common/overlay_base/etc/init.d/S99input-event-daemon
+++ b/board/tezuka/common/overlay_base/etc/init.d/S99input-event-daemon
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+[ -x /usr/bin/input-event-daemon ] || exit 0
+[ -e /dev/input/event0 ] || exit 0
+
+start() {
+	printf "Starting input-event-daemon: "
+	input-event-daemon && echo "OK" || echo "FAIL"
+}
+
+stop() {
+	printf "Stopping input-event-daemon: "
+	killall input-event-daemon 2>/dev/null && echo "OK" || echo "FAIL"
+}
+
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  restart|reload)
+	stop
+	start
+	;;
+  *)
+	echo "Usage: $0 {start|stop|reload|restart}"
+	exit 1
+esac

--- a/board/tezuka/common/overlay_tezuka/etc/init.d/S50gpsd
+++ b/board/tezuka/common/overlay_tezuka/etc/init.d/S50gpsd
@@ -9,11 +9,14 @@ DEVICES="/dev/ttyACM0"
 PIDFILE=/var/run/$NAME.pid
 GPSD_OPTIONS="-G -n -r"
 
+[ -x "$DAEMON" ] || exit 0
+
 start() {
         printf 'Starting %s: ' "$NAME"
-        start-stop-daemon -S -q -p $PIDFILE --exec $DAEMON -- -P $PIDFILE $DEVICES "$GPSD_OPTIONS" && echo "OK" || echo "Failed"
+        # shellcheck disable=SC2086
+        start-stop-daemon -S -q -p "$PIDFILE" --exec "$DAEMON" -- -P "$PIDFILE" $GPSD_OPTIONS "$DEVICES" && echo "OK" || echo "FAIL"
         sleep 3
-        gpsctl --nmea 
+        gpsctl --nmea
 }
 stop() {
         printf 'Stopping %s: ' "$NAME"

--- a/board/tezuka/common/post-build.sh
+++ b/board/tezuka/common/post-build.sh
@@ -34,7 +34,10 @@ genimage                           \
 	--config "${GENIMAGE_CFG}"
 
 rm -f "${TARGET_DIR}/opt/boot.vfat"
+# iiod is started by S23udc with RT priority and FunctionFS support.
+# Remove Buildroot's standalone iiod init script to prevent double-start.
 rm -f "${TARGET_DIR}/etc/init.d/S99iiod"
+rm -f "${TARGET_DIR}/etc/init.d/S60iiod"
 rm -rf "${BINARIES_DIR}/msd"
 
 ########################## ROOT FS INSTALL #############################


### PR DESCRIPTION
Three init scripts print stderr warnings on boards without the corresponding hardware: `gpsd` parses a quoted options bundle as one arg, `iiod` double-starts under Buildroot 2026.02's renamed `S99iiod`, and `input-event-daemon` runs unconditionally on input-less boards.

- `S50gpsd`: unquote options, add `/usr/sbin/gpsd` existence check
- `post-build.sh`: remove `S60iiod` (Buildroot 2026.02 ships `S99iiod`; `S23udc` also starts iiod with RT priority, so `S60iiod` created a double-start)
- New `S99input-event-daemon` overlay: guard on `/dev/input/event0`

Matrix CI: 12/12 boards build green. Hardware-validated on FISH Ball Rev.A (clean boot, no stderr warnings from dmesg tail).
