### PR TITLE
package(dropbear): raise MAX_UNAUTH_PER_IP to 20 for parallel tooling

### DIFF
--- a/board/tezuka/common/dropbear_localoptions.h
+++ b/board/tezuka/common/dropbear_localoptions.h
@@ -1,1 +1,7 @@
 #define DO_MOTD	1
+
+/* Raise from the upstream default of 5 to support parallel tooling
+ * (simultaneous scp + rapid-fire probes from a single ops workstation).
+ * Still bounded well below MAX_UNAUTH_CLIENTS (30) so one client cannot
+ * exhaust the global unauth session pool. */
+#define MAX_UNAUTH_PER_IP 20


### PR DESCRIPTION
Upstream default `MAX_UNAUTH_PER_IP=5` is too low for automation that opens several unauth sessions in rapid succession from one workstation (scp + status probes + parallel ssh commands). Empirical test: an 8-way parallel ssh burst from a single IP gets 3 connections dropped at the banner-exchange stage with "Socket is not connected".

- `board/tezuka/common/dropbear_localoptions.h`: `+#define MAX_UNAUTH_PER_IP 20`
- `MAX_UNAUTH_CLIENTS=30` unchanged — per-IP cap still bounded below the global pool
- Dropbear exposes no runtime flag for either constant; compile-time override via `BR2_PACKAGE_DROPBEAR_LOCALOPTIONS_FILE` is the only knob (confirmed against v2025.89)

Matrix CI: 12/12 boards build green. Hardware-validated on FISH Ball Rev.A (15-way staggered ssh burst now succeeds 15/15; previously broke at 6).
