### PR TITLE
fix(web): revamp of the visual appearance and consolidation of related web technologies

### DIFF
--- a/board/tezuka/common/msd/img/base.css
+++ b/board/tezuka/common/msd/img/base.css
@@ -1,0 +1,149 @@
+/* ── Tezuka base theme ──
+   Shared across all pages: landing, sweep, waterfall.
+   Dark, minimal, system fonts, safe, responsive.
+*/
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --bg:      #0f1117;
+  --surface: #1a1d27;
+  --border:  #2a2d3a;
+  --accent:  #4f8ff7;
+  --accent2: #8892a4;
+  --text:    #c8cdd8;
+  --muted:   #6b7280;
+  --head:    #e5e7eb;
+  --logo:    #e5e7eb;
+  color-scheme: dark;
+}
+
+html {
+  font-size: 15px;
+}
+
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Buttons ── */
+
+.btn, .btn-secondary {
+  display: inline-block;
+  text-decoration: none;
+  padding: 0.38rem 1rem;
+  border-radius: 5px;
+  border: none;
+  font-size: 0.83rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  color: inherit;
+}
+
+.btn {
+  background: var(--accent);
+  color: #fff;
+}
+
+.btn-secondary {
+  background: var(--surface);
+  color: var(--accent2);
+  border: 1px solid var(--border);
+}
+
+.btn:hover, .btn-secondary:hover {
+  opacity: 0.78;
+}
+
+/* ── Form elements ── */
+
+input, select, textarea, button {
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0.2rem 0.4rem;
+}
+
+input:focus, select:focus, textarea:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+}
+
+label {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+/* ── Tables ── */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--surface);
+  border-radius: 7px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+tr {
+  border-bottom: 1px solid var(--border);
+}
+
+tr:last-child {
+  border-bottom: none;
+}
+
+th, td {
+  padding: 0.42rem 0.8rem;
+  font-size: 0.82rem;
+  text-align: left;
+}
+
+th {
+  color: var(--muted);
+  font-weight: 500;
+  white-space: nowrap;
+  font-family: ui-monospace, "SF Mono", monospace;
+  font-size: 0.76rem;
+}
+
+td {
+  color: var(--head);
+  font-family: ui-monospace, "SF Mono", monospace;
+  word-break: break-all;
+}
+
+td:empty::after {
+  content: "—";
+  color: var(--muted);
+}
+
+/* ── Section headings ── */
+
+h2 {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+}
+
+/* ── Utility ── */
+
+.hidden {
+  display: none !important;
+}

--- a/board/tezuka/common/msd/img/style.css
+++ b/board/tezuka/common/msd/img/style.css
@@ -55,12 +55,6 @@ pre.logo {
   transition: color 0.15s;
 }
 
-.subtitle {
-  color: var(--muted);
-  font-size: 0.85rem;
-  margin-bottom: 1.5rem;
-}
-
 /* ── Nav ── */
 
 nav {

--- a/board/tezuka/common/msd/img/style.css
+++ b/board/tezuka/common/msd/img/style.css
@@ -1,31 +1,10 @@
-*, *::before, *::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
-
-:root {
-  --bg:      #ffffff;
-  --surface: #f7f8fa;
-  --border:  #e2e5eb;
-  --accent:  #2563eb;
-  --accent2: #64748b;
-  --text:    #374151;
-  --muted:   #9ca3af;
-  --head:    #111827;
-  --logo:    #111827;
-}
-
-html { font-size: 15px; }
+/* Landing page styles — imports shared base theme */
+@import url("base.css");
 
 body {
-  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
-  background: var(--bg);
-  color: var(--text);
   max-width: 640px;
   margin: 0 auto;
   padding: 2rem 1.5rem 4rem;
-  line-height: 1.5;
 }
 
 /* ── Header ── */
@@ -66,80 +45,12 @@ nav {
   border-bottom: 1px solid var(--border);
 }
 
-.btn, .btn-secondary {
-  display: inline-block;
-  text-decoration: none;
-  padding: 0.38rem 1rem;
-  border-radius: 5px;
-  font-size: 0.83rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  transition: opacity 0.15s;
-  cursor: pointer;
-}
-
-.btn {
-  background: var(--accent);
-  color: #fff;
-}
-
-.btn-secondary {
-  background: var(--surface);
-  color: var(--accent2);
-  border: 1px solid var(--border);
-}
-
-.btn:hover, .btn-secondary:hover { opacity: 0.78; }
-
 /* ── Sections ── */
 
 section {
   margin-bottom: 1.75rem;
 }
 
-h2 {
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--muted);
-  margin-bottom: 0.5rem;
-}
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-  background: var(--surface);
-  border-radius: 7px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-tr { border-bottom: 1px solid var(--border); }
-tr:last-child { border-bottom: none; }
-
-th, td {
-  padding: 0.42rem 0.8rem;
-  font-size: 0.82rem;
-  text-align: left;
-}
-
 th {
-  color: var(--muted);
-  font-weight: 500;
   width: 38%;
-  white-space: nowrap;
-  font-family: ui-monospace, monospace;
-  font-size: 0.76rem;
-}
-
-td {
-  color: var(--head);
-  font-family: ui-monospace, monospace;
-  word-break: break-all;
-}
-
-td:empty::after {
-  content: "—";
-  color: var(--muted);
 }

--- a/board/tezuka/common/msd/index.html
+++ b/board/tezuka/common/msd/index.html
@@ -19,7 +19,6 @@ ___________                  __
   |____| \___  >_____ \____/|__|_ \(____  /
              \/      \/          \/     \/</pre>
   </a>
-  <p class="subtitle">#MODEL# &mdash; #HOSTNAME#</p>
 </header>
 
 <nav>

--- a/board/tezuka/common/msd/index.html
+++ b/board/tezuka/common/msd/index.html
@@ -23,7 +23,7 @@ ___________                  __
 
 <nav>
   <a class="btn" href="sweep/index.html">SweepFFT</a>
-  <a class="btn" id="maia-link" href="#">Maia SDR</a>
+  <a class="btn" href="waterfall/">Maia SDR</a>
   <a class="btn-secondary" href="https://github.com/F5OEO/tezuka_fw">tezuka_fw</a>
   <a class="btn-secondary" href="https://github.com/F5OEO/tezuka_fw/blob/main/LICENSE">License</a>
 </nav>
@@ -63,8 +63,6 @@ ___________                  __
 </section>
 
 <script>
-  document.getElementById('maia-link').href =
-    window.location.protocol + '//' + window.location.hostname + ':8000';
   // Show the IP we're connected through if ETH IP was not set statically
   var ethCell = document.getElementById('eth-ip');
   if (ethCell && !ethCell.textContent.trim()) {

--- a/board/tezuka/common/msd/index.html
+++ b/board/tezuka/common/msd/index.html
@@ -22,7 +22,7 @@ ___________                  __
 </header>
 
 <nav>
-  <a class="btn" href="sweep/index.html">SweepFFT</a>
+  <a class="btn" id="sweep-link" href="sweep/index.html">SweepFFT</a>
   <a class="btn" href="waterfall/">Maia SDR</a>
   <a class="btn-secondary" href="https://github.com/F5OEO/tezuka_fw">tezuka_fw</a>
   <a class="btn-secondary" href="https://github.com/F5OEO/tezuka_fw/blob/main/LICENSE">License</a>
@@ -67,6 +67,16 @@ ___________                  __
   var ethCell = document.getElementById('eth-ip');
   if (ethCell && !ethCell.textContent.trim()) {
     ethCell.textContent = window.location.hostname;
+  }
+
+  // SweepFFT uses ws:// to mosquitto:9001. When the landing page is served
+  // over https, the browser blocks mixed content. Force the SweepFFT link
+  // to http:// so the sweep page itself runs plain-http and ws:// works.
+  // Tag the link with ?from=https so sweep's Back button can return to
+  // https (browsers strip Referer on https->http so that hint is gone).
+  var sweepLink = document.getElementById('sweep-link');
+  if (sweepLink && window.location.protocol === 'https:') {
+    sweepLink.href = 'http://' + window.location.hostname + '/sweep/?from=https';
   }
 </script>
 

--- a/board/tezuka/common/msd/sweep/index.html
+++ b/board/tezuka/common/msd/sweep/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div class="toolbar">
-    <a class="btn" href="/">&#x2190; Back</a>
+    <a class="btn" id="back-link" href="/">&#x2190; Back</a>
     <select name="rfinput" id="rfinput">
       <option value="rx1">rx1</option>
       <option value="rx2">rx2</option>
@@ -22,6 +22,15 @@
   <div class="waterfall">
     <canvas id="waterfall"></canvas>
   </div>
+  <script>
+    // Landing page rewrites the SweepFFT link to http:// so MQTT ws:// works
+    // and tags it with ?from=https. Send Back to https:// to return to the
+    // secure landing (browsers strip the Referer header across protocols).
+    var backLink = document.getElementById('back-link');
+    if (backLink && new URLSearchParams(window.location.search).get('from') === 'https') {
+      backLink.href = 'https://' + window.location.hostname + '/';
+    }
+  </script>
   <script src="colormap.js"></script>
   <script src="spectrum.js"></script>
   <script src="script.js"></script>

--- a/board/tezuka/common/msd/sweep/index.html
+++ b/board/tezuka/common/msd/sweep/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div class="toolbar">
-    <a class="btn" href="/index.html">Menu</a>
+    <a class="btn" href="/">&#x2190; Back</a>
     <select name="rfinput" id="rfinput">
       <option value="rx1">rx1</option>
       <option value="rx2">rx2</option>

--- a/board/tezuka/common/msd/sweep/index.html
+++ b/board/tezuka/common/msd/sweep/index.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="author" content="Jeppe Ledet-Pedersen">
   <title>SweepFFT</title>
-  <link rel="stylesheet" href="/img/style.css">
   <link rel="stylesheet" href="style.css">
   <link rel="shortcut icon" href="/img/favicon.ico" type="image/x-icon">
 </head>

--- a/board/tezuka/common/msd/sweep/index.html
+++ b/board/tezuka/common/msd/sweep/index.html
@@ -1,40 +1,32 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta name="author" content="Jeppe Ledet-Pedersen">
-        <title>Spectrum Plot</title>
-        <link rel="stylesheet" type="text/css" href="/img/style.css" />
-        <link rel="stylesheet" type="text/css" href="style.css" />
-        
-         <link rel="shortcut icon" href="/img/favicon.ico" type="image/x-icon">
-    </head>    
-    <body>
-        <div class="top_button_wrapper">
-        <a class="button" href="/index.html">Menu    
-        </a>
-        <label for="RfInput"></label>
-        <select name="rfinput" id="rfinput">
-          <option value="rx1">rx1</option>
-          <option value="rx2">rx2</option>
-      
-        </select>
-        <label for="rfgain">Rf Gain</label><input type="range" id="rfgain" name="Gain" min="0" max="71" step="0.25" default value="50" />
-        <span id="rfgain_val"></span>
-      
-      
-    </div>
-    </div>
-        <div class="waterfall">
-        <canvas id="waterfall"></canvas>
-       
-       
-    </div>      
-    <script src="colormap.js"></script>
-    <script src="spectrum.js"></script>
-    <script src="script.js"></script>
-    <script src="/paho-mqtt-min.js"></script>
-    <script src="maiaclient.js"></script>  
-        
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="author" content="Jeppe Ledet-Pedersen">
+  <title>SweepFFT</title>
+  <link rel="stylesheet" href="/img/style.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="shortcut icon" href="/img/favicon.ico" type="image/x-icon">
+</head>
+<body>
+  <div class="toolbar">
+    <a class="btn" href="/index.html">Menu</a>
+    <select name="rfinput" id="rfinput">
+      <option value="rx1">rx1</option>
+      <option value="rx2">rx2</option>
+    </select>
+    <label for="rfgain">Gain</label>
+    <input type="range" id="rfgain" name="Gain" min="0" max="71" step="0.25" value="50">
+    <span id="rfgain_val"></span>
+  </div>
+  <div class="waterfall">
+    <canvas id="waterfall"></canvas>
+  </div>
+  <script src="colormap.js"></script>
+  <script src="spectrum.js"></script>
+  <script src="script.js"></script>
+  <script src="/paho-mqtt-min.js"></script>
+  <script src="maiaclient.js"></script>
 </body>
 </html>

--- a/board/tezuka/common/msd/sweep/maiaclient.js
+++ b/board/tezuka/common/msd/sweep/maiaclient.js
@@ -1,6 +1,5 @@
-// URL de l'API REST
-//const apiUrl = "/api";
-const apiUrl = "http://"+window.location.hostname + ":8000"
+// URL de l'API REST — use current origin so it works on any port
+const apiUrl = window.location.origin
 
 // Fonction pour appeler l'API REST
 async function fetchData() {

--- a/board/tezuka/common/msd/sweep/script.js
+++ b/board/tezuka/common/msd/sweep/script.js
@@ -4,10 +4,8 @@ var spectrum, logger, ws, mqtt_client;
 
 function connectWebSocket(spectrum) {
 
-    //ws = new WebSocket("ws://" + window.location.host + ":7681/waterfall");
-    ws = new WebSocket("ws://" + window.location.hostname + ":8000/waterfall");
-    //ws = new WebSocket("wss://" + window.location.hostname + "/waterfall");
-    //ws = new WebSocket("ws://10.0.0.105:7681/waterfall");
+    var wsProto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    ws = new WebSocket(wsProto + "//" + window.location.host + "/waterfall");
     spectrum.setWebSocket(ws);
 
     ws.onconnect = function (evt) {

--- a/board/tezuka/common/msd/sweep/script.js
+++ b/board/tezuka/common/msd/sweep/script.js
@@ -112,13 +112,10 @@ function onConnect() {
     //console.log("onMessageArrived:"+message.destinationName+" "+message.payloadString);
     switch(message.destinationName)
     {
-        case "state/rx/frequency" : spectrum.setCenterHz(message.payloadString);spectrum.orginalfreq=message.payloadString;break;
-        case "state/rx/sampling" : 
-            spectrum.NativeSpan=message.payloadString;
-            if(spectrum.onsweep==0)
-            {
-                //spectrum.setSpanHz(message.payloadString);
-            }    
+        case "state/rx/frequency" : var f = Number(message.payloadString); if (!isNaN(f)) { spectrum.setCenterHz(f); spectrum.orginalfreq=f; } break;
+        case "state/rx/sampling" :
+            var s = Number(message.payloadString);
+            if (!isNaN(s)) { spectrum.NativeSpan=s; }
             break;
 
         case "state/rx/sweep/activate" :

--- a/board/tezuka/common/msd/sweep/spectrum.js
+++ b/board/tezuka/common/msd/sweep/spectrum.js
@@ -448,13 +448,19 @@ Spectrum.prototype.doAutoScale = function(bins) {
 }
 
 Spectrum.prototype.setCenterHz = function(hz) {
-    this.centerHz = hz;
-    this.updateAxes();
+    hz = Number(hz);
+    if (!isNaN(hz)) {
+        this.centerHz = hz;
+        this.updateAxes();
+    }
 }
 
 Spectrum.prototype.setSpanHz = function(hz) {
-    this.spanHz = hz;
-    this.updateAxes();
+    hz = Number(hz);
+    if (!isNaN(hz)) {
+        this.spanHz = hz;
+        this.updateAxes();
+    }
 }
 
 Spectrum.prototype.setGain = function(gain) {

--- a/board/tezuka/common/msd/sweep/spectrum.js
+++ b/board/tezuka/common/msd/sweep/spectrum.js
@@ -41,7 +41,7 @@ Spectrum.prototype.addWaterfallRow = function(bins) {
     if (this.wfrowcount % 100 == 0)
     {
         var timeString = new Date().toLocaleTimeString();
-        this.ctx_wf.font = "30px sans-serif";
+        this.ctx_wf.font = "30px system-ui, sans-serif";
         this.ctx_wf.fillStyle = "white";
         this.ctx_wf.textBaseline = "top";
         this.ctx_wf.fillText(timeString, 0, 0); // TODO: Fix font scaling
@@ -218,7 +218,7 @@ Spectrum.prototype.updateInfo = function(x) {
     this.ctx_InfoFrequency.clearRect(0, 0, width_text, 50+height_text);
 
     // Draw axes
-    this.ctx_InfoFrequency.font = "36px sans-serif";
+    this.ctx_InfoFrequency.font = "36px system-ui, sans-serif";
     this.ctx_InfoFrequency.fillStyle = "white";
     this.ctx_InfoFrequency.textBaseline = "middle";
 
@@ -243,7 +243,7 @@ Spectrum.prototype.updateAxes = function() {
     this.ctx_axes.clearRect(0, 0, width, height);
 
     // Draw axes
-    this.ctx_axes.font = "12px sans-serif";
+    this.ctx_axes.font = "12px system-ui, sans-serif";
     this.ctx_axes.fillStyle = "white";
     this.ctx_axes.textBaseline = "middle";
 

--- a/board/tezuka/common/msd/sweep/style.css
+++ b/board/tezuka/common/msd/sweep/style.css
@@ -1,8 +1,28 @@
 html, body {
-    width:  100%;
+    width: 100%;
     height: 100%;
-    margin: 0px;
-    padding: 0px;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+}
+
+.toolbar {
+    flex: 0 0 auto;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem;
+}
+
+.waterfall {
+    flex: 1 1 0;
+    min-height: 0;
 }
 
 #waterfall {
@@ -11,35 +31,20 @@ html, body {
     height: 100%;
 }
 
-.waterfall {
-    display: block;
-    width: 100%;
-    height: calc(100% - 60px);
-    margin: 0px;
-    padding: 0px;
-}
-
 .status {
     position: fixed;
-    width: 100%;
     top: 0;
-    right: 0;
     left: 50px;
+    right: 0;
     height: 30px;
-    text-align: left;
     line-height: 30px;
     color: white;
     font-size: 14px;
     font-family: "Lato", sans-serif;
     font-weight: 100;
+    pointer-events: none;
 }
 
 #log {
     white-space: nowrap;
-    text-shadow: 0 1px 0 darken(red, 10%);
-}
-.top_button_wrapper{
-    margin-bottom:10px ;
-    padding: 10px 0;
-    
 }

--- a/board/tezuka/common/msd/sweep/style.css
+++ b/board/tezuka/common/msd/sweep/style.css
@@ -21,6 +21,8 @@ body {
     padding: 0.5rem;
     background: var(--surface);
     border-bottom: 1px solid var(--border);
+    position: relative;
+    z-index: 10;
 }
 
 .waterfall {

--- a/board/tezuka/common/msd/sweep/style.css
+++ b/board/tezuka/common/msd/sweep/style.css
@@ -1,8 +1,9 @@
+/* SweepFFT page styles — imports shared base theme */
+@import url("/img/base.css");
+
 html, body {
     width: 100%;
     height: 100%;
-    margin: 0;
-    padding: 0;
     overflow: hidden;
 }
 
@@ -18,6 +19,8 @@ body {
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
 }
 
 .waterfall {
@@ -38,9 +41,8 @@ body {
     right: 0;
     height: 30px;
     line-height: 30px;
-    color: white;
+    color: var(--head);
     font-size: 14px;
-    font-family: "Lato", sans-serif;
     font-weight: 100;
     pointer-events: none;
 }

--- a/board/tezuka/common/overlay_base/etc/init.d/S40network
+++ b/board/tezuka/common/overlay_base/etc/init.d/S40network
@@ -211,9 +211,9 @@ create_system_files () {
 	printf "disable_usb_console = %s%s\n" "$DISABLE_USB_CONSOLE" "$CR" >> $CONF
 	printf "enable_ipv6 = %s%s\n" "$ENABLE_IPV6" "$CR" >> $CONF
 	printf "%s\n" "$CR" >> $CONF
-	### /www/index.html ###
+	### /root/index.html ###
 
-	sed -i -e "s/#IP#/$IPADDR/g" -e "s/#HOSTIP#/$IPADDR_HOST/g" -e "s/#NETMASK#/$NETMASK/g" -e "s/#HOSTNAME#/$HOSTNAME/g" -e "s/#SSID_WLAN#/$WLAN_SSID/g" -e "s/#IPADDR_WLAN#/$WLAN_IPADDR/g" -e "s/#IPADDR_ETH#/$ETH_IPADDR/g" -e "s/#NETMASK_ETH#/$ETH_NETMASK/g" -e "s/#GW_ETH#/$ETH_GW/g" -e "s/#MAC_ETH#/$ETH_MAC/g" /www/index.html
+	sed -i -e "s/#IP#/$IPADDR/g" -e "s/#HOSTIP#/$IPADDR_HOST/g" -e "s/#NETMASK#/$NETMASK/g" -e "s/#HOSTNAME#/$HOSTNAME/g" -e "s/#SSID_WLAN#/$WLAN_SSID/g" -e "s/#IPADDR_WLAN#/$WLAN_IPADDR/g" -e "s/#IPADDR_ETH#/$ETH_IPADDR/g" -e "s/#NETMASK_ETH#/$ETH_NETMASK/g" -e "s/#GW_ETH#/$ETH_GW/g" -e "s/#MAC_ETH#/$ETH_MAC/g" /root/index.html
 
 	}
 

--- a/board/tezuka/common/overlay_base/etc/init.d/S41network
+++ b/board/tezuka/common/overlay_base/etc/init.d/S41network
@@ -7,20 +7,17 @@ ETH_IPADDR=$(fw_printenv -n ipaddr_eth 2> /dev/null)
 
 case "$1" in
 	start)
-		printf "Starting dhcpd Daemon & httpd Server: "
+		printf "Starting dhcpd Daemon: "
 		start-stop-daemon -S -q -p /var/run/udhcpd.pid -x /usr/sbin/udhcpd -- "$UDHCPD_CONF"
 		start-stop-daemon -S -q -p /var/run/udhcpdwan.pid -x /usr/sbin/udhcpd -- /etc/udhcpdwan.conf
 		if [ "$ETH_IPADDR" = "AP" ]; then
 			start-stop-daemon -S -q -p /var/run/udhcpdlan.pid -x /usr/sbin/udhcpd -- /etc/udhcpdlan.conf
-		fi	
-		#httpd -h /www
-		/root/websrv /www &
+		fi
 		[ $? = 0 ] && echo "OK" || echo "FAIL"
 		;;
 
 	stop)
-		printf "Stopping dhcpd Daemon & httpd Server: "
-		killall -7 websrv
+		printf "Stopping dhcpd Daemon: "
 		start-stop-daemon -K -q -p /var/run/udhcpd.pid 2>/dev/null
 		start-stop-daemon -K -q -p /var/run/udhcpdwan.pid 2>/dev/null
 		start-stop-daemon -K -q -p /var/run/udhcpdlan.pid 2>/dev/null

--- a/board/tezuka/common/overlay_base/etc/init.d/S45msd
+++ b/board/tezuka/common/overlay_base/etc/init.d/S45msd
@@ -49,7 +49,7 @@ patch_html_page() {
 case "$1" in
 	start)
 		printf "Starting MSD Daemon: "
-		patch_html_page /www/index.html /www/img/version.js
+		patch_html_page /root/index.html /root/img/version.js
 		losetup /dev/loop7 $img -o 512
 		mount /dev/loop7 /mnt/msd
 
@@ -61,7 +61,7 @@ case "$1" in
 		cp $CONF /mnt/msd
 		md5sum /mnt/msd/config.txt > /opt/config.md5
 
-		cp -a /www/* /mnt/msd
+		cp -a /root/index.html /root/img /root/sweep /mnt/msd/
 		mv /mnt/msd/index.html /mnt/msd/info.html
 		umount /mnt/msd
 		echo $img > $file

--- a/board/tezuka/common/overlay_base/etc/init.d/S45msd
+++ b/board/tezuka/common/overlay_base/etc/init.d/S45msd
@@ -16,8 +16,21 @@ patch_html_page() {
 	MAC=$(cat /sys/kernel/config/usb_gadget/composite_gadget/functions/*/dev_addr)
 	IIO=$(iio_info -V 2>/dev/null | tail -1)
 	BUILD=$(grep device-fw /opt/VERSIONS | cut -d ' ' -f 2)
-	FPGA=$(grep hdl /opt/VERSIONS | cut -d ' ' -f 2)
+	UBOOT_VERSION=$(grep uboot /opt/VERSIONS | cut -d ' ' -f 2)
 	ROOTFS=$(grep buildroot /opt/VERSIONS | cut -d ' ' -f 2)
+
+	# Read FPGA (Maia SDR HDL) version from IP core register at 0x7c460004.
+	# Register layout: [31:24]=platform [23:16]=major [15:8]=minor [7:0]=bugfix
+	FPGA_REG=$(devmem 0x7c460004 32 2>/dev/null)
+	if [ -n "$FPGA_REG" ]; then
+		FPGA_NUM=$((FPGA_REG))
+		FPGA_MAJOR=$(( (FPGA_NUM >> 16) & 0xFF ))
+		FPGA_MINOR=$(( (FPGA_NUM >> 8) & 0xFF ))
+		FPGA_BUGFIX=$(( FPGA_NUM & 0xFF ))
+		FPGA="maia-hdl ${FPGA_MAJOR}.${FPGA_MINOR}.${FPGA_BUGFIX}"
+	else
+		FPGA=""
+	fi
 	USB_ETH_MODE=$(fw_printenv -n usb_ethernet_mode 2> /dev/null || echo rndis)
 	if [ "$USB_ETH_MODE" = "ncm" ]; then
 		NETWORKUSB="Communications Device Class – Network Control Model (CDC-NCM)"

--- a/board/tezuka/common/overlay_maia/etc/init.d/S60maia-httpd
+++ b/board/tezuka/common/overlay_maia/etc/init.d/S60maia-httpd
@@ -7,7 +7,7 @@ case "$1" in
             xz -d /usr/bin/maia-httpd.xz
         fi
         cd /root || exit
-        start-stop-daemon -S -b -q -m -p /var/run/maia-httpd.pid -x /usr/bin/maia-httpd -- --ssl-cert /mnt/jffs2/maia-httpd.crt --ssl-key /mnt/jffs2/maia-httpd.key --ca-cert /mnt/jffs2/maia-sdr-ca.crt
+        start-stop-daemon -S -b -q -m -p /var/run/maia-httpd.pid -x /usr/bin/maia-httpd -- --listen 0.0.0.0:80 --ssl-cert /mnt/jffs2/maia-httpd.crt --ssl-key /mnt/jffs2/maia-httpd.key --ca-cert /mnt/jffs2/maia-sdr-ca.crt
         cd - > /dev/null || exit
 	[ $? = 0 ] && echo "OK" || echo "FAIL"
 	;;

--- a/board/tezuka/common/post-build.sh
+++ b/board/tezuka/common/post-build.sh
@@ -48,17 +48,17 @@ INSTALL=install
 
 rm -Rf "${TARGET_DIR}/etc/dropbear"
 
-mkdir -p "${TARGET_DIR}/www/img"
-mkdir -p "${TARGET_DIR}/www/sweep"
+mkdir -p "${TARGET_DIR}/root/img"
+mkdir -p "${TARGET_DIR}/root/sweep"
 mkdir -p "${TARGET_DIR}/mnt/jffs2"
 mkdir -p "${TARGET_DIR}/mnt/msd"
 mkdir -p "${TARGET_DIR}/mnt/nfs"
 mkdir -p "${TARGET_DIR}/mnt/sd"
 mkdir -p "${TARGET_DIR}/etc/dropbear"
 
-${INSTALL} -D -m 0644 "${BOARD_DIR}/msd/img/"* "${TARGET_DIR}/www/img/"
-${INSTALL} -D -m 0644 "${BOARD_DIR}/msd/sweep/"* "${TARGET_DIR}/www/sweep/"
-${INSTALL} -D -m 0644 "${BOARD_DIR}/msd/"*.* "${TARGET_DIR}/www/"
+${INSTALL} -D -m 0644 "${BOARD_DIR}/msd/img/"* "${TARGET_DIR}/root/img/"
+${INSTALL} -D -m 0644 "${BOARD_DIR}/msd/sweep/"* "${TARGET_DIR}/root/sweep/"
+${INSTALL} -D -m 0644 "${BOARD_DIR}/msd/"*.* "${TARGET_DIR}/root/"
 
 ln -sf ../../wpa_supplicant/ifupdown.sh "${TARGET_DIR}/etc/network/if-up.d/wpasupplicant"
 ln -sf ../../wpa_supplicant/ifupdown.sh "${TARGET_DIR}/etc/network/if-down.d/wpasupplicant"

--- a/board/tezuka/common/post-build.sh
+++ b/board/tezuka/common/post-build.sh
@@ -19,7 +19,7 @@ sed -i s/##DEVICE_FW##/${FW_VERSION}/g "${BINARIES_DIR}/msd/LICENSE.html"
 sed -i s/##LINUX_VERSION##/${LINUX_VERS}/g "${BINARIES_DIR}/msd/LICENSE.html"
 sed -i s/##UBOOT_VERSION##/${UBOOT_VERS}/g "${BINARIES_DIR}/msd/LICENSE.html"
 
-BR_VERSION=$(grep '^BR2_VERSION_FULL' "${BR2_CONFIG}" 2>/dev/null | cut -d\" -f 2)
+BR_VERSION=$(sed -n 's/^VERSION_ID=//p' "${TARGET_DIR}/etc/os-release" 2>/dev/null)
 {
 	echo "device-fw tezuka-${FW_VERSION}"
 	echo "uboot ${UBOOT_VERS}"

--- a/board/tezuka/common/post-build.sh
+++ b/board/tezuka/common/post-build.sh
@@ -19,7 +19,12 @@ sed -i s/##DEVICE_FW##/${FW_VERSION}/g "${BINARIES_DIR}/msd/LICENSE.html"
 sed -i s/##LINUX_VERSION##/${LINUX_VERS}/g "${BINARIES_DIR}/msd/LICENSE.html"
 sed -i s/##UBOOT_VERSION##/${UBOOT_VERS}/g "${BINARIES_DIR}/msd/LICENSE.html"
 
-echo device-fw tezuka-${FW_VERSION}> "${TARGET_DIR}/opt/VERSIONS"
+BR_VERSION=$(grep '^BR2_VERSION_FULL' "${BR2_CONFIG}" 2>/dev/null | cut -d\" -f 2)
+{
+	echo "device-fw tezuka-${FW_VERSION}"
+	echo "uboot ${UBOOT_VERS}"
+	echo "buildroot ${BR_VERSION}"
+} > "${TARGET_DIR}/opt/VERSIONS"
 
 GENIMAGE_CFG="${BOARD_DIR}/genimage-msd.cfg"
 GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"

--- a/package/maia-wasm/0001-fix-html-validation-and-manifest-icons.patch
+++ b/package/maia-wasm/0001-fix-html-validation-and-manifest-icons.patch
@@ -1,0 +1,107 @@
+From: Tom Scogland <tom@tezuka.dev>
+Subject: [PATCH] fix HTML validation errors and broken manifest icon paths
+
+W3C validator and robustness fixes for maia-wasm assets:
+
+- index.html: remove duplicate autofocus (only one per document)
+- index.html: replace label[for] pointing at a <span> with a <div>
+  (W3C error: for= must reference a form control)
+- index.html: remove empty class="" attribute
+- index.html: normalize mixed tabs/spaces to spaces
+- index.html: strip trailing whitespace
+- manifest.json: fix "src:" typo to "src" so PWA icons actually load
+
+---
+ maia-wasm/assets/index.html    | 16 ++++++++--------
+ maia-wasm/assets/manifest.json |  8 ++++----
+ 2 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/maia-wasm/assets/index.html b/maia-wasm/assets/index.html
+index 1234567..abcdefg 100644
+--- a/maia-wasm/assets/index.html
++++ b/maia-wasm/assets/index.html
+@@ -40,9 +40,9 @@
+           <button id="other_tab" role="tab" aria-selected="false" aria-controls="other_panel">
+             Other
+           </button>
+-          <button id="close_settings" value="close" autofocus>Close</button>
++          <button id="close_settings" value="close">Close</button>
+         </div>
+-        <div id="recording_panel" class="" role="tabpanel" aria-labelledby="recording_tab">
++        <div id="recording_panel" role="tabpanel" aria-labelledby="recording_tab">
+           <form>
+             <label for="recording_metadata_filename">Filename</label>
+             <div class="div_value">
+@@ -62,7 +62,7 @@
+             </select>
+             <label for="recorder_maximum_duration">Max duration (s)</label>
+             <input type="number" min="0" step="any" id="recorder_maximum_duration">
+-            <label for="recording_metadata_geolocation">Geolocation</label>
++            <div class="div_label">Geolocation</div>
+             <div class="div_value">
+               <span id="recording_metadata_geolocation"></span>
+               <button type="button" id="recording_metadata_geolocation_update">Update</button>
+@@ -94,9 +94,9 @@
+           <form>
+             <label for="colormap_select">Colormap</label>
+             <select id="colormap_select">
+-	        <option>Turbo</option>
+-	        <option>Viridis</option>
+-	        <option>Inferno</option>
++              <option>Turbo</option>
++              <option>Viridis</option>
++              <option>Inferno</option>
+             </select>
+             <label for="waterfall_show_waterfall">Show waterfall</label>
+             <input type="checkbox" id="waterfall_show_waterfall" checked>
+@@ -110,7 +110,7 @@
+           <form>
+             <div>
+               <span id="geolocation_point"></span>
+-              <button type="button" id="geolocation_update">Update</button>            
++              <button type="button" id="geolocation_update">Update</button>
+               <button type="button" id="geolocation_clear">Clear</button>
+               <label for="geolocation_watch">Update continuously</label>
+               <input type="checkbox" id="geolocation_watch">
+@@ -153,8 +153,8 @@
+         </label>
+         <label>RX AGC
+           <select id="ad9361_rx_gain_mode">
+-	    <option>Manual</option>
+-	    <option>Fast attack</option>
++            <option>Manual</option>
++            <option>Fast attack</option>
+             <option>Slow attack</option>
+             <option>Hybrid</option>
+           </select>
+diff --git a/maia-wasm/assets/manifest.json b/maia-wasm/assets/manifest.json
+index 1234567..abcdefg 100644
+--- a/maia-wasm/assets/manifest.json
++++ b/maia-wasm/assets/manifest.json
+@@ -3,22 +3,22 @@
+     "name": "Maia SDR",
+     "icons": [
+         {
+-            "src:": "/maia-icon-32x32.png",
++            "src": "/maia-icon-32x32.png",
+             "type": "image/png",
+             "sizes": "32x32"
+         },
+         {
+-            "src:": "/maia-icon-128x128.png",
++            "src": "/maia-icon-128x128.png",
+             "type": "image/png",
+             "sizes": "128x128"
+         },
+         {
+-            "src:": "/maia-icon-180x180.png",
++            "src": "/maia-icon-180x180.png",
+             "type": "image/png",
+             "sizes": "180x180"
+         },
+         {
+-            "src:": "/maia-icon-192x192.png",
++            "src": "/maia-icon-192x192.png",
+             "type": "image/png",
+             "sizes": "192x192"
+         }

--- a/package/maia-wasm/0002-system-ui-font-and-back-nav.patch
+++ b/package/maia-wasm/0002-system-ui-font-and-back-nav.patch
@@ -1,0 +1,62 @@
+From: tezuka <tezuka@firmware.local>
+Subject: [PATCH] use system-ui font for canvas text and add Back nav link
+
+The canvas frequency labels used generic 'sans' which renders as a
+dull fallback. Switch to 'system-ui, sans-serif' to match the system
+UI font.
+
+Add a Back navigation link in the bottom toolbar so users can return
+to the landing page without using the browser back button.
+
+---
+ maia-wasm/assets/index.html              | 1 +
+ maia-wasm/assets/style.css               | 9 +++++++++
+ maia-wasm/src/render/engine/text.rs      | 2 +-
+ 3 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/maia-wasm/src/render/engine/text.rs b/maia-wasm/src/render/engine/text.rs
+--- a/maia-wasm/src/render/engine/text.rs
++++ b/maia-wasm/src/render/engine/text.rs
+@@ -56,7 +56,7 @@
+     }
+ 
+     fn set_font(&self, height_px: u32) {
+-        self.context.set_font(&format!("bold {height_px}px sans"))
++        self.context.set_font(&format!("bold {height_px}px system-ui, sans-serif"))
+     }
+ 
+     pub fn render(
+diff --git a/maia-wasm/assets/index.html b/maia-wasm/assets/index.html
+--- a/maia-wasm/assets/index.html
++++ b/maia-wasm/assets/index.html
+@@ -129,12 +129,13 @@
+     <div class="main_screen">
+       <canvas id="canvas"></canvas>
+ 
+       <form class="ui">
++        <a class="nav_back" href="/">&#x2190; Back</a>
+         <fieldset class="waterfall_levels">
+           <label for="waterfall_min">Waterfall min</label>/<label for="waterfall_max">max</label>
+           <input type="number" id="waterfall_min" value="35" step="1" min="0">
+           <input type="number" id="waterfall_max" value="85" step="1" min="0">
+         </fieldset>
+         <label>RX freq
+           <input type="number" class="rf_frequency" id="ad9361_rx_lo_frequency" step="0.001" min="70" max="6000">
+           MHz
+         </label>
+diff --git a/maia-wasm/assets/style.css b/maia-wasm/assets/style.css
+--- a/maia-wasm/assets/style.css
++++ b/maia-wasm/assets/style.css
+@@ -367,3 +367,12 @@
+ #geolocation_panel div {
+     grid-column: 1/3;
+ }
++
++/* Back navigation */
++
++.nav_back {
++    color: var(--text-color);
++    text-decoration: none;
++    font-size: 0.875rem;
++    font-weight: 600;
++}

--- a/package/maia-wasm/maia-wasm.mk
+++ b/package/maia-wasm/maia-wasm.mk
@@ -19,9 +19,9 @@ define MAIA_WASM_BUILD_CMDS
 endef
 
 define MAIA_WASM_INSTALL_TARGET_CMDS
-	mkdir -p $(TARGET_DIR)/root/pkg
-	cp -r $(@D)/maia-wasm/pkg/* $(TARGET_DIR)/root/pkg/
-	cp -r $(@D)/maia-wasm/assets/* $(TARGET_DIR)/root/
+	mkdir -p $(TARGET_DIR)/root/waterfall/pkg
+	cp -r $(@D)/maia-wasm/pkg/* $(TARGET_DIR)/root/waterfall/pkg/
+	cp -r $(@D)/maia-wasm/assets/* $(TARGET_DIR)/root/waterfall/
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
- **Device info:** read FPGA version at runtime from `maia-hdl` IP core register via `devmem 0x7c460004`, write U-Boot and Buildroot versions to `/opt/VERSIONS` at build time, read `VERSION_ID` from `/etc/os-release` for Root FS
- **Sweepfft:** responsive flexbox layout, viewport meta tag, dark theme via shared `base.css`, system-ui canvas fonts, toolbar `z-index` fix, NaN guard on `setCenterHz`/`setSpanHz`, ← Back navigation
- **Sweepfft networking:** WebSocket URL uses `window.location.host` instead of hardcoded `:8000`, API URL in `maiaclient.js` uses `window.location.origin`
- **Maia-wasm patches** (applied at build time): fix W3C validation error, fix manifest `src:` typo, switch canvas font to system-ui, add ← Back nav link
- **Dark theme:** shared `base.css` with dark color scheme, system fonts, consistent form/table/button styling
- **Server consolidation:** remove `websrv`, add `--listen 0.0.0.0:80` to `maia-httpd` — all content served on `:80` (HTTP) and `:443` (HTTPS). Waterfall moved to `/waterfall/`, landing page at `/`. `S40network` and `S45msd` paths updated from `/www/` to `/root/`
- **HTTPS → SweepFFT:** from the https landing, rewrite the SweepFFT link to `http://host/sweep/?from=https` so the sweep page itself runs plain-http and `ws://` to mosquitto works cleanly. SweepFFT's ← Back reads `?from=https` and returns to `https://host/` (browsers strip `Referer` across protocols). Landing + Maia waterfall remain fully https; SweepFFT is local LAN device control traffic
