### PR TITLE
cleanup: fix shebangs and quote variables in tool scripts

### DIFF
--- a/tools/init_maia.sh
+++ b/tools/init_maia.sh
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env bash
 
 freq=110000000
 decim=48

--- a/tools/test_onram.sh
+++ b/tools/test_onram.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #sshpass -p analog ssh root@pluto.local '/usr/sbin/pluto_reboot ram;'
 #sleep 5
 sudo dfu-util -d 0456:b673,0456:b674 -D ./build/pluto.dfu -a firmware.dfu -R

--- a/tools/update_release.sh
+++ b/tools/update_release.sh
@@ -1,5 +1,6 @@
+#!/usr/bin/env bash
 release=0.1.9
-cd /tmp
+cd /tmp || exit 1
 #e200
 wget https://github.com/F5OEO/tezuka_fw/releases/download/"$release"/antsdr_e200.zip -O antsdr_e200.zip && mkdir -p antsdr_e200 && unzip -o antsdr_e200.zip -d antsdr_e200 \
 && sshpass -p 'analog' scp -r antsdr_e200/sdimg/* root@antsdre200.local:/mnt/sd && sshpass -p 'analog' ssh root@antsdre200.local "reboot"

--- a/update_bitstream.sh
+++ b/update_bitstream.sh
@@ -1,5 +1,6 @@
+#!/usr/bin/env bash
 commit_path="${BR2_EXTERNAL::-1}"
-git add $commit_path/board/*/bitstream/fsbl.elf
-git add $commit_path/board/*/bitstream/maia-iio/*
-git add $commit_path/board/*/bitstream/overclock/*
-git commit -m "Update bistream"$1
+git add "$commit_path"/board/*/bitstream/fsbl.elf
+git add "$commit_path"/board/*/bitstream/maia-iio/*
+git add "$commit_path"/board/*/bitstream/overclock/*
+git commit -m "Update bistream${1}"


### PR DESCRIPTION
Minor hygiene pass over the `tools/` scripts and `update_bitstream.sh`:

- Add missing shebangs where absent
- Quote variable expansions to handle paths with spaces / empty values

Files touched:
- `tools/init_maia.sh`
- `tools/test_onram.sh`
- `tools/update_release.sh`
- `update_bitstream.sh`

No behaviour change; shellcheck clean.