### PR TITLE
feat: add IIO benchmark script for on-device performance testing

### DIFF
--- a/tools/iio_benchmark.sh
+++ b/tools/iio_benchmark.sh
@@ -46,11 +46,32 @@ get_sample_rate() {
 run_readdev_bench() {
     _bs="$1"
     # iio_readdev -B prints throughput to stderr with ANSI escape sequences
-    # strip escapes, take last non-empty throughput value
+    # strip escapes, split runs, take last throughput line, split off error trailers.
     timeout "$STREAM_DURATION" iio_readdev -u "$URI" -b "$_bs" -B "$RX_DEV" \
         >/dev/null 2>/tmp/iio_bench_out || true
-    sed 's/\x1b\[[0-9]*K//g' /tmp/iio_bench_out 2>/dev/null \
-        | tr '\r' '\n' | grep -i throughput | tail -1 || echo "ERROR"
+    _line=$(sed 's/\x1b\[[0-9]*K//g' /tmp/iio_bench_out 2>/dev/null \
+        | tr '\r' '\n' | grep -i throughput | tail -1)
+    if [ -z "$_line" ]; then
+        echo "ERROR"
+        return
+    fi
+    # strip anything after "MiB/s" (Unable to refill... glue trailer)
+    _thr=$(echo "$_line" | sed -E 's/(MiB\/s).*/\1/')
+    # detect trailing refill error on same line
+    echo "$_line" | grep -q "refill buffer.*timed out" && _thr="$_thr (refill ETIMEDOUT)"
+    echo "$_thr"
+}
+
+read_temp_c() {
+    _raw=$(iio_read_chan_attr temp0 input)
+    if [ -n "$_raw" ] && [ "$_raw" -gt 0 ] 2>/dev/null; then
+        # millidegC -> degC with one decimal
+        _int=$((_raw / 1000))
+        _frac=$(( (_raw % 1000) / 100 ))
+        echo "${_int}.${_frac}°C (raw ${_raw})"
+    else
+        echo "n/a"
+    fi
 }
 
 kconfig_check() {
@@ -96,7 +117,8 @@ echo "rx_dev:        $RX_DEV"
 echo "sample_rate:   $(get_sample_rate)"
 echo "rx_path_rates: $(iio_read_dev_attr rx_path_rates)"
 echo "tx_path_rates: $(iio_read_dev_attr tx_path_rates)"
-echo "temperature:   $(iio_read_chan_attr temp0 input)"
+echo "temp_pre:      $(read_temp_c)"
+echo "loadavg_pre:   $(cut -d' ' -f1-3 /proc/loadavg 2>/dev/null)"
 echo ""
 
 # ===================================================================
@@ -105,7 +127,10 @@ lsmod
 echo ""
 
 # ===================================================================
-echo "=== FPGA OVERFLOW REGISTERS (pre-test) ==="
+# NOTE: these addresses in the Maia-SDR IP core are reported as overflow
+# counters in some docs, but empirically read as static IP-core identity
+# on fishball7020 (constant 0x00000251 pre/post). Captured for diffing.
+echo "=== FPGA REGISTERS pre (0x79020400,440,480,4C0) ==="
 for addr in 0x79020400 0x79020440 0x79020480 0x790204C0; do
     val=$(busybox devmem "$addr" 32 2>/dev/null || echo "n/a")
     echo "  $addr = $val"
@@ -139,7 +164,7 @@ done
 echo ""
 
 # ===================================================================
-echo "=== FPGA OVERFLOW REGISTERS (post-test) ==="
+echo "=== FPGA REGISTERS post (0x79020400,440,480,4C0) ==="
 for addr in 0x79020400 0x79020440 0x79020480 0x790204C0; do
     val=$(busybox devmem "$addr" 32 2>/dev/null || echo "n/a")
     echo "  $addr = $val"
@@ -147,16 +172,31 @@ done
 echo ""
 
 # ===================================================================
-echo "=== STRESS TEST (${STRESS_DURATION}s, ${STRESS_THREADS} threads) ==="
+echo "=== TEMP + LOAD (mid-sweep) ==="
+echo "temp_mid:      $(read_temp_c)"
+echo "loadavg_mid:   $(cut -d' ' -f1-3 /proc/loadavg 2>/dev/null)"
+echo ""
+
+# ===================================================================
+# iio_stresstest without -v: avoids 14k lines of per-refill error spam,
+# keeps the per-slice totals/histogram lines (those aren't verbose-gated).
+echo "=== STRESS TEST (${STRESS_DURATION}s, ${STRESS_THREADS} threads, 4 kB buf) ==="
 set_sample_rate "$SWEEP_RATE"
 timeout "$((STRESS_DURATION + 5))" \
     iio_stresstest -u "$URI" -b 4096 -t "$STRESS_THREADS" \
-    -T "$STRESS_DURATION" -v "$RX_DEV" 2>&1 || true
+    -T "$STRESS_DURATION" "$RX_DEV" 2>&1 \
+    | grep -E "^total:|^  *[0-9]+.*[0-9]+.*%|^Ran|buffer_refill failed" \
+    | awk '!seen[$0]++ || /^total:/ || /Ran/' || true
 echo ""
 
 # ===================================================================
 # restore default sample rate
 set_sample_rate "$SWEEP_RATE"
+
+echo "=== POST-RUN ==="
+echo "temp_post:     $(read_temp_c)"
+echo "loadavg_post:  $(cut -d' ' -f1-3 /proc/loadavg 2>/dev/null)"
+echo ""
 
 echo "=== DONE ==="
 echo "label: $LABEL"

--- a/tools/iio_benchmark.sh
+++ b/tools/iio_benchmark.sh
@@ -1,0 +1,166 @@
+#!/bin/sh
+# IIO Benchmark Script for Tezuka Firmware
+# Runs on-device (BusyBox sh compatible)
+#
+# Usage: sh iio_benchmark.sh [label]
+#   label: optional experiment name (e.g. "tier1-hardening")
+#
+# Output: plain text to stdout. Redirect to save:
+#   sh iio_benchmark.sh "baseline" > /tmp/benchmark.txt
+
+set -e
+
+LABEL="${1:-unnamed}"
+URI="local:"
+RX_DEV="cf-ad9361-lpc"
+PHY_DEV="ad9361-phy"
+SWEEP_RATE=30720000
+SWEEP_BUFSZ=65536
+STREAM_DURATION=10
+STRESS_DURATION=60
+STRESS_THREADS=2
+
+# helpers — iio_attr output format: "... value: 'xxx'" or "... value 'xxx'"
+iio_read_dev_attr() {
+    iio_attr -u "$URI" -d "$PHY_DEV" "$1" 2>/dev/null | sed "s/.*value[: ]*'//" | sed "s/'$//"
+}
+
+iio_read_chan_attr() {
+    # -i = input channel; $1=channel $2=attr
+    iio_attr -u "$URI" -i -c "$PHY_DEV" "$1" "$2" 2>/dev/null | sed "s/.*value[: ]*'//" | sed "s/'$//"
+}
+
+iio_set_chan_attr() {
+    # -i = input channel; $1=channel $2=attr $3=value
+    iio_attr -u "$URI" -i -c "$PHY_DEV" "$1" "$2" "$3" >/dev/null 2>&1
+}
+
+set_sample_rate() {
+    iio_set_chan_attr voltage0 sampling_frequency "$1"
+}
+
+get_sample_rate() {
+    iio_read_chan_attr voltage0 sampling_frequency
+}
+
+run_readdev_bench() {
+    _bs="$1"
+    # iio_readdev -B prints throughput to stderr with ANSI escape sequences
+    # strip escapes, take last non-empty throughput value
+    timeout "$STREAM_DURATION" iio_readdev -u "$URI" -b "$_bs" -B "$RX_DEV" \
+        >/dev/null 2>/tmp/iio_bench_out || true
+    sed 's/\x1b\[[0-9]*K//g' /tmp/iio_bench_out 2>/dev/null \
+        | tr '\r' '\n' | grep -i throughput | tail -1 || echo "ERROR"
+}
+
+kconfig_check() {
+    if [ -f /proc/config.gz ]; then
+        zcat /proc/config.gz 2>/dev/null | grep -w "$1" | head -1
+    else
+        echo "n/a"
+    fi
+}
+
+# ===================================================================
+echo "=== IIO BENCHMARK ==="
+echo "label:    $LABEL"
+echo "date:     $(date -Iseconds 2>/dev/null || date)"
+echo "host:     $(hostname)"
+echo "uptime:   $(cut -d' ' -f1 /proc/uptime)s"
+echo ""
+
+# ===================================================================
+echo "=== SYSTEM INFO ==="
+echo "kernel:   $(uname -r)"
+echo "arch:     $(uname -m)"
+echo "cmdline:  $(cat /proc/cmdline)"
+echo ""
+
+# ===================================================================
+echo "=== KERNEL CONFIG ==="
+for k in CONFIG_HZ CONFIG_PREEMPT CONFIG_PREEMPT_RT \
+         CONFIG_STACKPROTECTOR_STRONG CONFIG_FORTIFY_SOURCE \
+         CONFIG_STRICT_KERNEL_RWX CONFIG_STRICT_MODULE_RWX \
+         CONFIG_SLUB CONFIG_SLAB CONFIG_HW_RANDOM; do
+    val=$(kconfig_check "$k")
+    if [ -n "$val" ]; then
+        echo "  $val"
+    fi
+done
+echo ""
+
+# ===================================================================
+echo "=== IIO DEVICE INFO ==="
+echo "phy:           $PHY_DEV"
+echo "rx_dev:        $RX_DEV"
+echo "sample_rate:   $(get_sample_rate)"
+echo "rx_path_rates: $(iio_read_dev_attr rx_path_rates)"
+echo "tx_path_rates: $(iio_read_dev_attr tx_path_rates)"
+echo "temperature:   $(iio_read_chan_attr temp0 input)"
+echo ""
+
+# ===================================================================
+echo "=== MODULES ==="
+lsmod
+echo ""
+
+# ===================================================================
+echo "=== FPGA OVERFLOW REGISTERS (pre-test) ==="
+for addr in 0x79020400 0x79020440 0x79020480 0x790204C0; do
+    val=$(busybox devmem "$addr" 32 2>/dev/null || echo "n/a")
+    echo "  $addr = $val"
+done
+echo ""
+
+# ===================================================================
+echo "=== BUFFER SIZE SWEEP (sample_rate=$SWEEP_RATE) ==="
+set_sample_rate "$SWEEP_RATE"
+actual=$(get_sample_rate)
+echo "actual_rate: $actual"
+echo ""
+printf "%-12s  %s\n" "buffer_size" "throughput"
+printf "%-12s  %s\n" "-----------" "----------"
+for bs in 256 1024 4096 16384 65536 262144; do
+    result=$(run_readdev_bench "$bs")
+    printf "%-12s  %s\n" "$bs" "$result"
+done
+echo ""
+
+# ===================================================================
+echo "=== SAMPLE RATE SWEEP (buffer_size=$SWEEP_BUFSZ) ==="
+printf "%-14s  %-14s  %s\n" "requested" "actual" "throughput"
+printf "%-14s  %-14s  %s\n" "---------" "------" "----------"
+for sr in 2500000 10000000 20000000 30720000 40000000 61440000; do
+    set_sample_rate "$sr"
+    actual=$(get_sample_rate)
+    result=$(run_readdev_bench "$SWEEP_BUFSZ")
+    printf "%-14s  %-14s  %s\n" "$sr" "$actual" "$result"
+done
+echo ""
+
+# ===================================================================
+echo "=== FPGA OVERFLOW REGISTERS (post-test) ==="
+for addr in 0x79020400 0x79020440 0x79020480 0x790204C0; do
+    val=$(busybox devmem "$addr" 32 2>/dev/null || echo "n/a")
+    echo "  $addr = $val"
+done
+echo ""
+
+# ===================================================================
+echo "=== STRESS TEST (${STRESS_DURATION}s, ${STRESS_THREADS} threads) ==="
+set_sample_rate "$SWEEP_RATE"
+timeout "$((STRESS_DURATION + 5))" \
+    iio_stresstest -u "$URI" -b 4096 -t "$STRESS_THREADS" \
+    -T "$STRESS_DURATION" -v "$RX_DEV" 2>&1 || true
+echo ""
+
+# ===================================================================
+# restore default sample rate
+set_sample_rate "$SWEEP_RATE"
+
+echo "=== DONE ==="
+echo "label: $LABEL"
+echo "date:  $(date -Iseconds 2>/dev/null || date)"
+
+# cleanup
+rm -f /tmp/iio_bench_out


### PR DESCRIPTION
Adds `tools/iio_benchmark.sh`, a self-contained script for profiling AD9361 / IIO sample-rate throughput and CPU load directly on-target.

### Sample output — fishball7020

```
=== IIO BENCHMARK ===
label:    future-14d67fe-v2
date:     2026-04-18T01:18:25+00:00
host:     fishball7020
uptime:   6906.00s

=== SYSTEM INFO ===
kernel:   6.12.77
arch:     armv7l
cmdline:  console=ttyPS0,115200 rootfstype=ramfs root=/dev/ram0 rw rootwait earlycon clk_ignore_unused cpuidle.off=1 uio_pdrv_genirq.of_id=uio_pdrv_genirq UBOOT_MODEBOOT=sdboot UBOOT_VERSION=""

=== KERNEL CONFIG ===
  CONFIG_HZ=1000
  CONFIG_PREEMPT=y
  CONFIG_STACKPROTECTOR_STRONG=y
  CONFIG_FORTIFY_SOURCE=y
  CONFIG_STRICT_KERNEL_RWX=y
  CONFIG_STRICT_MODULE_RWX=y
  CONFIG_SLUB=y
  CONFIG_HW_RANDOM=y

=== IIO DEVICE INFO ===
phy:           ad9361-phy
rx_dev:        cf-ad9361-lpc
sample_rate:   30720000
rx_path_rates: BBPLL:983040000 ADC:245760000 R2:122880000 R1:61440000 RF:30720000 RXSAMP:30720000
tx_path_rates: BBPLL:983040000 DAC:245760000 T2:122880000 T1:61440000 TF:30720000 TXSAMP:30720000
temp_pre:      25.4°C (raw 25439)
loadavg_pre:   0.80 0.95 0.86

=== MODULES ===
Module                  Size  Used by    Tainted: G  
maia_sdr               12288  4 

=== FPGA REGISTERS pre (0x79020400,440,480,4C0) ===
  0x79020400 = 0x00000251
  0x79020440 = 0x00000251
  0x79020480 = 0x00000251
  0x790204C0 = 0x00000251

=== BUFFER SIZE SWEEP (sample_rate=30720000) ===
actual_rate: 30720000

buffer_size   throughput
-----------   ----------
256           Throughput: 92 MiB/s (refill ETIMEDOUT)
1024          Throughput: 203 MiB/s (refill ETIMEDOUT)
4096          Throughput: 222 MiB/s
16384         Throughput: 235 MiB/s
65536         Throughput: 234 MiB/s
262144        Throughput: 234 MiB/s

=== SAMPLE RATE SWEEP (buffer_size=65536) ===
requested       actual          throughput
---------       ------          ----------
2500000         2500000         Throughput: 18 MiB/s
10000000        10000000        Throughput: 76 MiB/s
20000000        20000000        Throughput: 152 MiB/s
30720000        30720000        Throughput: 234 MiB/s
40000000        40000000        Throughput: 305 MiB/s
61440000        61440000        Throughput: 469 MiB/s

=== FPGA REGISTERS post (0x79020400,440,480,4C0) ===
  0x79020400 = 0x00000251
  0x79020440 = 0x00000251
  0x79020480 = 0x00000251
  0x790204C0 = 0x00000251

=== TEMP + LOAD (mid-sweep) ===
temp_mid:      26.3°C (raw 26316)
loadavg_mid:   0.80 0.92 0.86

=== STRESS TEST (60s, 2 threads, 4 kB buf) ===
0 : IIO ERROR : iio_buffer_refill failed : Connection timed out (110)
1 : IIO ERROR : iio_buffer_refill failed : Connection timed out (110)
total: 1m04s Context : 1277 (19.65/s), buffers: 23355 (359.43/s), refills : 566 (8.71/s)
    0        :       0 ( 0.00%)
  1 - 9   μs :       1 ( 0.16%)
 10 - 99  μs :      20 ( 3.12%)
  1 - 9.9 ms :     272 (42.43%)
 10 - 99  ms :     173 (26.99%)

=== POST-RUN ===
temp_post:     26.3°C (raw 26316)
loadavg_post:  2.21 1.36 1.02

=== DONE ===
label: future-14d67fe-v2
date:  2026-04-18T01:21:15+00:00
```