### PR TITLE
dts: 6.12 mdio subnode migration + correct realtek phy ids

### DIFF
--- a/board/tezuka/e200/dts/zynq-e200.dtsi
+++ b/board/tezuka/e200/dts/zynq-e200.dtsi
@@ -101,24 +101,26 @@
 
 &gem0 {
 	status = "okay";
-	
+
 	phy-handle = <&phy0>;
 	phy-mode = "rgmii-rxid";
-	xlnx,has-mdio = <0x1>;
 	gmii2rgmii-phy-handle = <&gmii_to_rgmii_0>;
-	
-	phy0: phy@1 {
-		compatible = "ethernet-phy-id011c.c916";
-		device_type = "ethernet-phy";
-		reg = <0x1>;
-	};
 
-	gmii_to_rgmii_0: gmiitorgmii@8 {
-		compatible = "xlnx,gmii-to-rgmii-1.0";
-		reg = <0x8>;
-		phy-handle = <&phy0>;
-	};
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
 
+		phy0: ethernet-phy@1 {
+			compatible = "ethernet-phy-id011c.c916";
+			reg = <0x1>;
+		};
+
+		gmii_to_rgmii_0: gmiitorgmii@8 {
+			compatible = "xlnx,gmii-to-rgmii-1.0";
+			reg = <0x8>;
+			phy-handle = <&phy0>;
+		};
+	};
 };
 
 &qspi {

--- a/board/tezuka/e200/dts/zynq-e200.dtsi
+++ b/board/tezuka/e200/dts/zynq-e200.dtsi
@@ -110,8 +110,9 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		phy0: ethernet-phy@1 {
-			compatible = "ethernet-phy-id011c.c916";
+		phy0: ethernet-phy@1 { /* Realtek RTL8211F */
+			compatible = "ethernet-phy-id001c.c916",
+				     "ethernet-phy-ieee802.3-c22";
 			reg = <0x1>;
 		};
 

--- a/board/tezuka/fishball7010/dts/fishball.dtsi
+++ b/board/tezuka/fishball7010/dts/fishball.dtsi
@@ -100,9 +100,14 @@
 	phy-mode = "rgmii-id";
 	phy-handle = <&phy0>;
 
-	phy0: phy@0 { /* Marvell 88e1512 */
-		reg = <0>;
-		compatible = "ethernet-phy-ieee802.3-c22";
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy0: ethernet-phy@0 { /* Marvell 88e1512 */
+			reg = <0>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+		};
 	};
 };
 

--- a/board/tezuka/libre/dts/zynq-libre.dtsi
+++ b/board/tezuka/libre/dts/zynq-libre.dtsi
@@ -116,10 +116,14 @@
 	phy-mode = "rgmii-id";
 	phy-handle = <&phy0>;
 
-	phy0: phy@0 { /* Marvell 88e1512 */
-		reg = <0>;
-		compatible = "ethernet-phy-ieee802.3-c22";
-		reset-gpios = <&gpio0 46 1>;
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy0: ethernet-phy@0 { /* Marvell 88e1512 */
+			reg = <0>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+		};
 	};
 };
 

--- a/board/tezuka/plutoplus/dts/zynq-maiaplutoplus.dts
+++ b/board/tezuka/plutoplus/dts/zynq-maiaplutoplus.dts
@@ -45,9 +45,15 @@ found in https://github.com/plutoplus/plutoplus/blob/master/patches/linux.diff
         pinctrl-0 = <&pinctrl_gem0_default>;
         phy-mode = "rgmii-id";
         phy-handle = <&ethernet_phy>;
-        ethernet_phy: ethernet-phy@1 {
-                reg = <1>;
-                device_type = "ethernet_phy";
+
+        mdio {
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                ethernet_phy: ethernet-phy@1 {
+                        reg = <1>;
+                        compatible = "ethernet-phy-ieee802.3-c22";
+                };
         };
 };
 

--- a/board/tezuka/plutoplus/dts/zynq-maiaplutoplus.dts
+++ b/board/tezuka/plutoplus/dts/zynq-maiaplutoplus.dts
@@ -50,9 +50,10 @@ found in https://github.com/plutoplus/plutoplus/blob/master/patches/linux.diff
                 #address-cells = <1>;
                 #size-cells = <0>;
 
-                ethernet_phy: ethernet-phy@1 {
+                ethernet_phy: ethernet-phy@1 { /* Realtek RTL8211E */
                         reg = <1>;
-                        compatible = "ethernet-phy-ieee802.3-c22";
+                        compatible = "ethernet-phy-id001c.c915",
+                                     "ethernet-phy-ieee802.3-c22";
                 };
         };
 };

--- a/board/tezuka/plutoplus/dts/zynq-plutoplus.dts
+++ b/board/tezuka/plutoplus/dts/zynq-plutoplus.dts
@@ -44,9 +44,15 @@ found in https://github.com/plutoplus/plutoplus/blob/master/patches/linux.diff
         pinctrl-0 = <&pinctrl_gem0_default>;
         phy-mode = "rgmii-id";
         phy-handle = <&ethernet_phy>;
-        ethernet_phy: ethernet-phy@1 {
-                reg = <1>;
-                device_type = "ethernet_phy";
+
+        mdio {
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                ethernet_phy: ethernet-phy@1 {
+                        reg = <1>;
+                        compatible = "ethernet-phy-ieee802.3-c22";
+                };
         };
 };
 

--- a/board/tezuka/plutoplus/dts/zynq-plutoplus.dts
+++ b/board/tezuka/plutoplus/dts/zynq-plutoplus.dts
@@ -49,9 +49,10 @@ found in https://github.com/plutoplus/plutoplus/blob/master/patches/linux.diff
                 #address-cells = <1>;
                 #size-cells = <0>;
 
-                ethernet_phy: ethernet-phy@1 {
+                ethernet_phy: ethernet-phy@1 { /* Realtek RTL8211E */
                         reg = <1>;
-                        compatible = "ethernet-phy-ieee802.3-c22";
+                        compatible = "ethernet-phy-id001c.c915",
+                                     "ethernet-phy-ieee802.3-c22";
                 };
         };
 };

--- a/board/tezuka/plutoplus/dts/zynq-plutoplus.dtsi
+++ b/board/tezuka/plutoplus/dts/zynq-plutoplus.dtsi
@@ -67,10 +67,14 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_gem0_default>;
 
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-	ethernet_phy: ethernet-phy@1 {
-		reg = <1>;
-		device_type = "ethernet-phy";
+		ethernet_phy: ethernet-phy@1 {
+			reg = <1>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+		};
 	};
 };
 

--- a/board/tezuka/plutoplus/dts/zynq-plutoplus.dtsi
+++ b/board/tezuka/plutoplus/dts/zynq-plutoplus.dtsi
@@ -71,9 +71,10 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		ethernet_phy: ethernet-phy@1 {
+		ethernet_phy: ethernet-phy@1 { /* Realtek RTL8211E */
 			reg = <1>;
-			compatible = "ethernet-phy-ieee802.3-c22";
+			compatible = "ethernet-phy-id001c.c915",
+				     "ethernet-phy-ieee802.3-c22";
 		};
 	};
 };

--- a/board/tezuka/plutoskyr2/dts/fishball.dtsi
+++ b/board/tezuka/plutoskyr2/dts/fishball.dtsi
@@ -106,8 +106,9 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		phy0: ethernet-phy@1 {
-			compatible = "ethernet-phy-id011c.c916";
+		phy0: ethernet-phy@1 { /* Realtek RTL8211F */
+			compatible = "ethernet-phy-id001c.c916",
+				     "ethernet-phy-ieee802.3-c22";
 			reg = <0x1>;
 		};
 

--- a/board/tezuka/plutoskyr2/dts/fishball.dtsi
+++ b/board/tezuka/plutoskyr2/dts/fishball.dtsi
@@ -97,24 +97,26 @@
 
 &gem0 {
 	status = "okay";
-	
+
 	phy-handle = <&phy0>;
 	phy-mode = "rgmii-rxid";
-	xlnx,has-mdio = <0x1>;
 	gmii2rgmii-phy-handle = <&gmii_to_rgmii_0>;
-	
-	phy0: phy@1 {
-		compatible = "ethernet-phy-id011c.c916";
-		device_type = "ethernet-phy";
-		reg = <0x1>;
-	};
 
-	gmii_to_rgmii_0: gmiitorgmii@8 {
-		compatible = "xlnx,gmii-to-rgmii-1.0";
-		reg = <0x8>;
-		phy-handle = <&phy0>;
-	};
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
 
+		phy0: ethernet-phy@1 {
+			compatible = "ethernet-phy-id011c.c916";
+			reg = <0x1>;
+		};
+
+		gmii_to_rgmii_0: gmiitorgmii@8 {
+			compatible = "xlnx,gmii-to-rgmii-1.0";
+			reg = <0x8>;
+			phy-handle = <&phy0>;
+		};
+	};
 };
 
 &qspi {

--- a/board/tezuka/signalsdrpro/dts/zynq-signalsdrpro.dtsi
+++ b/board/tezuka/signalsdrpro/dts/zynq-signalsdrpro.dtsi
@@ -97,10 +97,14 @@
 	phy-mode = "rgmii-id";
 	phy-handle = <&phy0>;
 
-	phy0: phy@0 { /* Marvell 88e1512 */
-		reg = <0>;
-		compatible = "ethernet-phy-ieee802.3-c22";
-		reset-gpios = <&gpio0 46 1>;
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy0: ethernet-phy@0 { /* Marvell 88e1512 */
+			reg = <0>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+		};
 	};
 };
 


### PR DESCRIPTION
## What

Port the 6.12 MDIO subnode migration (established for e310 by 0c0032b) to the remaining boards carrying an external PHY under gem0, then bind the correct Realtek chip-specific driver on plutoplus / e200 / plutoskyr2.

## Commits

1. **dts: adopt 6.12 mdio subnode style for gem0 phys on all boards** — structural migration on signalsdrpro, libre, fishball7010 (shared with fishball7020), plutoplus (3 files), e200, plutoskyr2. Wraps each PHY in an explicit `mdio { }` subnode, renames `phy@N` to `ethernet-phy@N`, drops the deprecated `device_type = "ethernet-phy"`, drops the legacy `xlnx,has-mdio` hint on e200/plutoskyr2 (now implicit via the explicit subnode). No change to PHY addresses or existing `reset-gpios` on any board.
2. **dts: bind chip-specific realtek phy drivers on plutoplus/e200/plutoskyr2** — sets correct `ethernet-phy-idXXXX.YYYY` compatible: `0x001CC915` (RTL8211E) on plutoplus, `0x001CC916` (RTL8211F) on e200/plutoskyr2. Fixes a long-standing `0x011CC916` typo in the vendor DTS that made the RTL8211F fall through to the generic c22 driver — likely the root cause of flaky ethernet on e200/plutoskyr2 under 6.12. Verified against `drivers/net/phy/realtek.c` in linux v6.12 and ADI Linux 7330e07.

## PHY wiring (F5OEO schematic-confirmed)

| Board | PHY | MDIO addr | Reset |
|---|---|---|---|
| signalsdrpro, libre, fishball7010/7020 | Marvell 88E1512 | 0 | grounded / POR (no GPIO) |
| plutoplus | Realtek RTL8211E | 1 | grounded |
| e200, plutoskyr2 | Realtek RTL8211F | 1 | grounded (unchecked, conservative default) |

Only e310 (existing `iETH_nRST` on GPIO 46) retains a `reset-gpios` declaration.

## What's NOT in this PR

- u-boot DTS reset-line corrections (companion PRs)
- any kernel driver or defconfig changes
- phy-mode changes on any board

## Testing

Commit 1 bisectable: no regression on any board (same generic driver fallback as pre-patch on boards where the id binding changes).
Commit 2: e310 validated by 0c0032b. Other boards deferred to maintainer lab.
