### PR TITLE
dts(u-boot): correct e310 marvell phy reset polarity to active-low

### DIFF
--- a/board/tezuka/e310/u-boot-dts/zynq-pluto-sdr.dts
+++ b/board/tezuka/e310/u-boot-dts/zynq-pluto-sdr.dts
@@ -90,7 +90,7 @@
 
 	ethernet_phy0: ethernet-phy@0 {
 		reg = <0>;
-		reset-gpios = <&gpio0 46 0>;
+		reset-gpios = <&gpio0 46 1>;
 	};
 };
 


### PR DESCRIPTION
## What

The e310 u-boot DTS declared the Marvell 88E1512 reset line as active-high:

    reset-gpios = <&gpio0 46 0>;

Schematic confirmation: GPIO 46 on e310 is wired to the PHY reset pin with net name `iETH_nRST` (active-low). The kernel DTS is already active-low (via 0c0032b), so the u-boot DTS has been inconsistent with both the schematic and the kernel.

This PR flips the polarity flag from 0 to 1 to match hardware.

## Impact

U-boot's zynq_gem driver typically pulses the reset and does not rely on the declared polarity to hold reset between sessions, which is why the inconsistency has not caused observable breakage. Fix is documentation-level correctness and avoids confusion for future u-boot driver work.

## What's NOT in this PR

- kernel DTS changes (companion PR #297)
- signalsdrpro / libre u-boot reset wiring (companion PR #299 — those boards have no GPIO-driven reset, declaration removal instead of polarity flip)
