### PR TITLE
dts(u-boot): remove spurious phy reset-gpios on signalsdrpro/libre

### DIFF
--- a/board/tezuka/libre/u-boot-dts/zynq-pluto-sdr.dts
+++ b/board/tezuka/libre/u-boot-dts/zynq-pluto-sdr.dts
@@ -111,6 +111,5 @@
 
 	ethernet_phy0: ethernet-phy@0 {
 		reg = <0>;
-		reset-gpios = <&gpio0 46 0>;
 	};
 };

--- a/board/tezuka/signalsdrpro/u-boot-dts/zynq-pluto-sdr.dts
+++ b/board/tezuka/signalsdrpro/u-boot-dts/zynq-pluto-sdr.dts
@@ -103,6 +103,5 @@
 
 	ethernet_phy0: ethernet-phy@0 {
 		reg = <0>;
-		reset-gpios = <&gpio0 46 0>;
 	};
 };


### PR DESCRIPTION
## What

The signalsdrpro and libre u-boot DTS each declared a PHY reset line:

    reset-gpios = <&gpio0 46 0>;

Schematic confirmation: on both boards the Marvell 88E1512 reset pin is wired directly to a fixed rail (grounded at the PCB level, i.e. permanently deasserted), not to any Zynq GPIO. GPIO 46 drives no ethernet-related signal on these boards; the `reset-gpios` declaration was vestigial, probably copied from e310 without schematic verification.

This PR removes the line. No `reset-gpios` on either PHY — matching the fishball and plutoplus u-boot DTS, which also have no ethernet reset line wired to a GPIO.

## What's NOT in this PR

- kernel DTS changes (companion PR #297)
- e310 u-boot polarity fix (companion PR #298 — e310 has a real GPIO-driven reset, just with the wrong polarity flag)
