### PR TITLE
ci: improve release pipeline — ccache, changelog range, per-author notes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   # Tag pushes publish a GitHub release with git-cliff notes and per-board
-  # zips. Strict SemVer pattern excludes legacy tags (0.x.y, Tezuka_*, v1.6.1).
+  # zips. SemVer pattern (v-prefixed) triggers the release pipeline.
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -116,8 +116,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /home/runner/.buildroot-ccache
-          key: ccache-${{ matrix.board }}-${{ hashFiles('buildroot.version') }}
-          restore-keys: ccache-${{ matrix.board }}-
+          key: ccache-v2-${{ matrix.board }}-${{ hashFiles('buildroot.version') }}
+          restore-keys: ccache-v2-${{ matrix.board }}-
 
       # Tree cache keyed on buildroot.version + patches/ so bumping Buildroot
       # or a patch invalidates. On cold cache each matrix leg populates its
@@ -136,7 +136,11 @@ jobs:
         run: ./getbuildroot.sh
 
       - name: Configure ${{ matrix.board }}
-        run: make -C buildroot O="${OUTPUT_DIR}" ${{ matrix.defconfig }}
+        run: |
+          make -C buildroot O="${OUTPUT_DIR}" ${{ matrix.defconfig }}
+          echo 'BR2_CCACHE=y' >> "${OUTPUT_DIR}/.config"
+          echo 'BR2_CCACHE_DIR="/home/runner/.buildroot-ccache"' >> "${OUTPUT_DIR}/.config"
+          make -C buildroot O="${OUTPUT_DIR}" olddefconfig
 
       - name: Build U-Boot
         run: make -C buildroot O="${OUTPUT_DIR}" uboot
@@ -195,14 +199,34 @@ jobs:
         with:
           fetch-depth: 0     # git-cliff walks full history
 
+      - name: Compute changelog range
+        id: cliff-range
+        env:
+          TAG: ${{ github.ref_name }}
+          FALLBACK_BASE: 365ea2e
+        run: |
+          set -euo pipefail
+          PREV_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
+            | grep -v "^${TAG}$" | head -1 || true)
+          if [ -n "$PREV_TAG" ]; then
+            RANGE="${PREV_TAG}..${TAG}"
+          else
+            RANGE="${FALLBACK_BASE}..${TAG}"
+          fi
+          echo "range=${RANGE}" >> "$GITHUB_OUTPUT"
+          echo "Changelog range: ${RANGE}"
+
       - name: Generate release notes
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --latest --strip header
+          args: >-
+            ${{ steps.cliff-range.outputs.range }}
+            --strip header
         env:
           OUTPUT: NOTES.md
           GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/download-artifact@v8
         with:
@@ -215,18 +239,19 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          REV="${GITHUB_SHA::7}"
           # Artifacts come down as tezuka-<board>/. Zip each as
-          # tezuka-<board>-<tag>.zip for the release.
+          # tezuka-<board>-<tag>-<rev>.zip for the release.
           for dir in artifacts/tezuka-*/; do
             board="$(basename "${dir%/}")"
             board="${board#tezuka-}"
-            mv "${dir%/}" "artifacts/tezuka-${board}-${TAG}"
-            (cd artifacts && zip -rq "../tezuka-${board}-${TAG}.zip" "tezuka-${board}-${TAG}")
+            mv "${dir%/}" "artifacts/tezuka-${board}-${TAG}-${REV}"
+            (cd artifacts && zip -rq "../tezuka-${board}-${TAG}-${REV}.zip" "tezuka-${board}-${TAG}-${REV}")
           done
           # Prerelease if tag has a dash suffix (vX.Y.Z-rc1), stable otherwise.
           flags=""
           [[ "$TAG" == *-* ]] && flags="--prerelease"
-          gh release create "$TAG" $flags --title "$TAG" --notes-file NOTES.md tezuka-*.zip
+          gh release create "$TAG" $flags --draft --title "$TAG" --notes-file NOTES.md tezuka-*.zip
           # Release summary for the workflow run page.
           {
             echo "## Release ${TAG}"

--- a/cliff.toml
+++ b/cliff.toml
@@ -3,29 +3,40 @@
 
 [changelog]
 body = """
-{% for group, commits in commits | group_by(attribute="group") %}
-### {{ group | upper_first }}
+{% for author, commits in commits | group_by(attribute="author.name") %}
+### Commits — {{ author }}{% if commits[0].remote.username %} (@{{ commits[0].remote.username }}){% endif %}
 {% for commit in commits %}
-- {{ commit.message | split(pat="\n") | first | trim }} ({{ commit.id | truncate(length=7, end="") }}{% if commit.remote.username %}, @{{ commit.remote.username }}{% endif %})
+- {{ commit.message | split(pat="\n") | first | trim | upper_first }} \
+  ([{{ commit.id | truncate(length=7, end="") }}](REPOSITORY_URL/commit/{{ commit.id }}))
 {%- endfor %}
 {% endfor %}
+{% if github.contributors | length > 0 %}
+### Contributors
+
+Thank you for contributing to this project!
+
+{% for contributor in github.contributors %}
+- @{{ contributor.username }}
+{%- endfor %}
+{% endif %}
 """
 trim = true
+postprocessors = [
+  { pattern = "REPOSITORY_URL", replace = "https://github.com/F5OEO/tezuka_fw" },
+]
 
 [git]
-conventional_commits = true
+conventional_commits = false
 filter_unconventional = false
-commit_parsers = [
-  { message = "^feat",                           group = "<!-- 0 -->Features" },
-  { message = "^fix",                            group = "<!-- 1 -->Bug Fixes" },
-  { message = "^dts|^kernel|^uboot|^init",       group = "<!-- 2 -->Kernel / U-Boot / DTS" },
-  { message = "^bitstream|^board|^[Ff]pga",      group = "<!-- 3 -->FPGA / Board" },
-  { message = "^package",                        group = "<!-- 4 -->Packages" },
-  { message = "^buildroot|^defconfig",           group = "<!-- 5 -->Buildroot" },
-  { message = "^build|^ci|^toolchain",           group = "<!-- 6 -->Build / CI" },
-  { message = "^docs?",                          group = "<!-- 7 -->Documentation" },
-  { message = "^cleanup|^refactor",              group = "<!-- 8 -->Cleanup" },
-  { message = ".*",                              group = "<!-- 9 -->Other" },
+commit_preprocessors = [
+  { pattern = '\\(#([0-9]+)\\)', replace = "([#${1}](REPOSITORY_URL/pull/${1}))" },
+  # Strip conventional commit prefixes for cleaner display.
+  { pattern = "^[a-zA-Z]+(?:\\([^)]*\\))?!?:\\s*", replace = "" },
 ]
-tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+(-.+)?$"
+commit_parsers = [
+  { message = "(?i)^merge",   skip = true },
+  { message = "(?i)^revert",  skip = true },
+]
+# Only v-prefixed tags create release boundaries.
+tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+"
 sort_commits = "newest"


### PR DESCRIPTION
Improvements to the CI/release pipeline introduced in PR #301.

### Changes

- **ccache**: Enable `BR2_CCACHE=y` for Buildroot builds — was cached but never activated. Bump cache key to `v2` to invalidate empty caches from pre-ccache era.
- **Changelog range**: Replace `git-cliff --latest` with explicit range computation — previous v-tagged release as baseline, `365ea2e` fallback for first release. Fixes full-history dump when no matching previous tag exists.
- **Per-author grouping**: Changelog now groups commits by author with clickable GitHub usernames. Requires `GITHUB_TOKEN` for contributor resolution.
- **Cleaner display**: Strip conventional commit prefixes (`feat:`, `fix:`, etc.) from changelog entries. Skip merge and revert commits.
- **Artifact naming**: Add short git rev to release zip filenames (`tezuka-board-tag-rev.zip`).
- **Draft releases**: Releases created as drafts for manual review before publishing.

### Note on merge strategy

The per-author changelog works best with "**Squash and merge" PR strategy**. With "Create a merge commit", individual PR commits appear as separate entries mixed with direct commits. Squash merges give one clean entry per PR per author.
