### PR TITLE
package(hamlib): bump 4.5.5 to 4.7.1

### DIFF
--- a/package/hamlib/hamlib.hash
+++ b/package/hamlib/hamlib.hash
@@ -1,0 +1,2 @@
+# Locally calculated (GitHub auto-archive of tag 4.7.1)
+sha256 653908e463745c85de76919e3d2b64998503c22a83421a7add0c5b10a5bf6a24  4.7.1.tar.gz

--- a/package/hamlib/hamlib.mk
+++ b/package/hamlib/hamlib.mk
@@ -1,4 +1,4 @@
-HAMLIB_VERSION = 4.5.5
+HAMLIB_VERSION = 4.7.1
 HAMLIB_SITE = https://github.com/Hamlib/Hamlib/archive/refs/tags
 HAMLIB_SOURCE = $(HAMLIB_VERSION).tar.gz
 HAMLIB_AUTORECONF=YES


### PR DESCRIPTION
## Summary

Bump Buildroot package `hamlib` from **4.5.5** (2022) to **4.7.1** (2026-04-16). 4.7.1 is a security and bug-fix release on the 4.7.x line; upstream changelog: https://github.com/Hamlib/Hamlib/compare/4.5.5...4.7.1

## Autoconf

`HAMLIB_AUTORECONF=YES` is already set in `hamlib.mk`, so the bumped tarball regenerates `configure` via Buildroot's host autotools — no local autotools regeneration needed.

## Integrity

`hamlib.hash` is added (it was previously missing) so Buildroot now SHA256-verifies the GitHub auto-archive of tag `4.7.1`. Hash was locally computed:

```
sha256  653908e463745c85de76919e3d2b64998503c22a83421a7add0c5b10a5bf6a24  4.7.1.tar.gz
```