### PR TITLE
fix(nano): remove usb-phy from DTS to fix USB gadget

### DIFF
--- a/board/tezuka/common/overlay_base/etc/init.d/S23udc
+++ b/board/tezuka/common/overlay_base/etc/init.d/S23udc
@@ -118,7 +118,8 @@ case "$1" in
 
 	mkdir -p $GADGET/configs/c.1
 	mkdir -p $GADGET/configs/c.1/strings/0x409
-	echo "RNDIS/MSD/ACM/IIOUSBD" > $GADGET/configs/c.1/strings/0x409/configuration
+	USB_ETH_MODE_UPPER=$(echo "$USB_ETH_MODE" | tr '[:lower:]' '[:upper:]')
+	echo "${USB_ETH_MODE_UPPER}/MSD/ACM/IIOUSBD" > $GADGET/configs/c.1/strings/0x409/configuration
 	echo 500 > $GADGET/configs/c.1/MaxPower
 	
 if [ "$AUDIO_MODE" = "on" ]
@@ -156,7 +157,8 @@ if [ "$AUDIO_MODE" = "on" ]
 	if [ "$AUDIO_MODE" = "on" ]
 	then
 	ln -s $GADGET/functions/uac2.usb0 $GADGET/configs/c.1
-	echo "Config 1: ECM network" > $GADGET/configs/c.1/strings/0x409/configuration
+	USB_ETH_MODE_UPPER=$(echo "$USB_ETH_MODE" | tr '[:lower:]' '[:upper:]')
+	echo "Config 1: ${USB_ETH_MODE_UPPER} + Audio network" > $GADGET/configs/c.1/strings/0x409/configuration
 	#ln -s $GADGET/functions/hid.keyboard $GADGET/configs/c.1
 	fi
 	

--- a/board/tezuka/nano/dts/nano.dtsi
+++ b/board/tezuka/nano/dts/nano.dtsi
@@ -86,7 +86,6 @@
 	xlnx,phy-reset-gpio = <&gpio0 46 0>;
 	dr_mode = "otg";
 	status = "okay";
-	usb-phy = <&usb_phy0>;
 };
 
 


### PR DESCRIPTION
## 🐛 Summary

Fix nano USB gadget — the DTS included a `usb-phy` phandle to a generic `ulpi-phy` node that conflicted with the chipidea driver's own PHY detection, causing `-110 (ETIMEDOUT)` when reading ULPI registers. Removing the phandle lets the chipidea driver handle the SMSC USB3320 PHY internally.

This fix should apply to any board showing `ci_hdrc: unable to init phy: -110` in `dmesg`.

## 🔀 Commits

| Commit | Description |
|--------|-------------|
| `7aef67a` | 🐛 fix(nano): remove usb-phy from DTS to fix USB gadget |
| `cabd76d` | 💄 style(S23udc): reflect actual USB ethernet mode in config string

## 🖼️ Screenshot

<img width="1120" height="575" alt="image" src="https://github.com/user-attachments/assets/dc1c008d-ecd0-43e5-bd6a-988ee404e44a" />
