### PR TITLE
dts(libre): add interrupt-parent to rx/tx DMA — fix no RX capture on kernel 6.12

### DIFF
--- a/board/tezuka/libre/dts/zynq-libre.dtsi
+++ b/board/tezuka/libre/dts/zynq-libre.dtsi
@@ -6,7 +6,7 @@
  *
  * Licensed under the GPL-2.
  */
-#include "zynq.dtsi"
+#include "zynq-7000.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>
@@ -179,6 +179,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c400000 0x10000>;
 			#dma-cells = <1>;
+			interrupt-parent = <&intc>;
 			interrupts = <0 57 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 
@@ -200,6 +201,7 @@
 			compatible = "adi,axi-dmac-1.00.a";
 			reg = <0x7c420000 0x10000>;
 			#dma-cells = <1>;
+			interrupt-parent = <&intc>;
 			interrupts = <0 56 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clkc 16>;
 


### PR DESCRIPTION
## Problem

On the 6.12 ADI kernel (current `main`/`future`), the libre board has **no RX capture device** — all libiio / SDR++ / GNU Radio streaming returns nothing. The kernel log shows:

```
dma-axi-dmac 7c400000.dma: error -ENXIO: IRQ index 0 not found
```

The `rx_dma` / `tx_dma` nodes in `zynq-libre.dtsi` are missing `interrupt-parent = <&intc>`. On 6.12 the `axi-dmac` driver no longer resolves the IRQ implicitly, so it fails to probe and `cf-ad9361-lpc` is deferred forever. The web UI / maia-sdr spectrometer still work because the `maia-sdr` node already had `interrupt-parent` — only the two DMA nodes were missed in the 6.12 adaptation.

## Fix

- Add `interrupt-parent = <&intc>` to both `rx_dma` (`7c400000`) and `tx_dma` (`7c420000`).
- Update the kernel include `zynq.dtsi` → `zynq-7000.dtsi` (the file was renamed in the 6.12 tree).

3 lines, no functional change beyond restoring DMA IRQ binding.

## Validation

Hardware-tested on a LibreSDR (Zynq-7020 + AD9361) on the 6.12 image: after the fix `cf-ad9361-lpc` probes, and libiio streaming (cs16 + cs12) works end-to-end (overflow 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)