### PR TITLE
Enable kernel PPS clients so a pulse-per-second can reach userspace

### DIFF
--- a/board/tezuka/common/kernel/zynq_pluto_linux_defconfig
+++ b/board/tezuka/common/kernel/zynq_pluto_linux_defconfig
@@ -220,10 +220,14 @@ CONFIG_SPI_CADENCE=y
 CONFIG_SPI_XILINX=y
 CONFIG_SPI_ZYNQ_QSPI=y
 CONFIG_SPI_SPIDEV=y
-#CONFIG_PPS=y
-#CONFIG_NTP_PPS=y
-#CONFIG_PPS_CLIENT_KTIMER=y
-#CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS=y
+CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS_CLIENT_GPIO=y
+# CONFIG_NTP_PPS (the in-kernel hardpps consumer) is left off: it depends on a
+# periodic kernel (!NO_HZ) which these configs do not run, and chrony reads
+# /dev/pps directly so nothing here needs it.
+# CONFIG_PPS_CLIENT_KTIMER is left off deliberately: it fabricates test pulses,
+# and a /dev/pps that ticks without any GPS attached is a trap, not a feature.
 CONFIG_GPIOLIB=y
 CONFIG_GPIO_SYSFS=y
 CONFIG_GPIO_ZYNQ=y

--- a/board/tezuka/common/kernel/zynq_pluto_linux_mini_defconfig
+++ b/board/tezuka/common/kernel/zynq_pluto_linux_mini_defconfig
@@ -201,10 +201,14 @@ CONFIG_SPI_CADENCE=y
 CONFIG_SPI_XILINX=y
 CONFIG_SPI_ZYNQ_QSPI=y
 CONFIG_SPI_SPIDEV=y
-#CONFIG_PPS=y
-#CONFIG_NTP_PPS=y
-#CONFIG_PPS_CLIENT_KTIMER=y
-#CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS=y
+CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS_CLIENT_GPIO=y
+# CONFIG_NTP_PPS (the in-kernel hardpps consumer) is left off: it depends on a
+# periodic kernel (!NO_HZ) which these configs do not run, and chrony reads
+# /dev/pps directly so nothing here needs it.
+# CONFIG_PPS_CLIENT_KTIMER is left off deliberately: it fabricates test pulses,
+# and a /dev/pps that ticks without any GPS attached is a trap, not a feature.
 CONFIG_GPIOLIB=y
 CONFIG_GPIO_SYSFS=y
 CONFIG_GPIO_ZYNQ=y

--- a/board/tezuka/e200/kernel/zynq_pluto_linux_defconfig
+++ b/board/tezuka/e200/kernel/zynq_pluto_linux_defconfig
@@ -198,10 +198,14 @@ CONFIG_SPI_CADENCE=y
 CONFIG_SPI_XILINX=y
 CONFIG_SPI_ZYNQ_QSPI=y
 CONFIG_SPI_SPIDEV=y
-#CONFIG_PPS=y
-#CONFIG_NTP_PPS=y
-#CONFIG_PPS_CLIENT_KTIMER=y
-#CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS=y
+CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS_CLIENT_GPIO=y
+# CONFIG_NTP_PPS (the in-kernel hardpps consumer) is left off: it depends on a
+# periodic kernel (!NO_HZ) which these configs do not run, and chrony reads
+# /dev/pps directly so nothing here needs it.
+# CONFIG_PPS_CLIENT_KTIMER is left off deliberately: it fabricates test pulses,
+# and a /dev/pps that ticks without any GPS attached is a trap, not a feature.
 CONFIG_GPIOLIB=y
 CONFIG_GPIO_SYSFS=y
 CONFIG_GPIO_ZYNQ=y

--- a/board/tezuka/e310/kernel/zynq_pluto_linux_defconfig
+++ b/board/tezuka/e310/kernel/zynq_pluto_linux_defconfig
@@ -198,10 +198,14 @@ CONFIG_SPI_CADENCE=y
 CONFIG_SPI_XILINX=y
 CONFIG_SPI_ZYNQ_QSPI=y
 CONFIG_SPI_SPIDEV=y
-#CONFIG_PPS=y
-#CONFIG_NTP_PPS=y
-#CONFIG_PPS_CLIENT_KTIMER=y
-#CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS=y
+CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS_CLIENT_GPIO=y
+# CONFIG_NTP_PPS (the in-kernel hardpps consumer) is left off: it depends on a
+# periodic kernel (!NO_HZ) which these configs do not run, and chrony reads
+# /dev/pps directly so nothing here needs it.
+# CONFIG_PPS_CLIENT_KTIMER is left off deliberately: it fabricates test pulses,
+# and a /dev/pps that ticks without any GPS attached is a trap, not a feature.
 CONFIG_GPIOLIB=y
 CONFIG_GPIO_SYSFS=y
 CONFIG_GPIO_ZYNQ=y

--- a/board/tezuka/fishball7010/kernel/zynq_pluto_linux_defconfig
+++ b/board/tezuka/fishball7010/kernel/zynq_pluto_linux_defconfig
@@ -199,10 +199,14 @@ CONFIG_SPI_CADENCE=y
 CONFIG_SPI_XILINX=y
 CONFIG_SPI_ZYNQ_QSPI=y
 CONFIG_SPI_SPIDEV=y
-#CONFIG_PPS=y
-#CONFIG_NTP_PPS=y
-#CONFIG_PPS_CLIENT_KTIMER=y
-#CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS=y
+CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS_CLIENT_GPIO=y
+# CONFIG_NTP_PPS (the in-kernel hardpps consumer) is left off: it depends on a
+# periodic kernel (!NO_HZ) which these configs do not run, and chrony reads
+# /dev/pps directly so nothing here needs it.
+# CONFIG_PPS_CLIENT_KTIMER is left off deliberately: it fabricates test pulses,
+# and a /dev/pps that ticks without any GPS attached is a trap, not a feature.
 CONFIG_GPIOLIB=y
 CONFIG_GPIO_SYSFS=y
 CONFIG_GPIO_ZYNQ=y

--- a/board/tezuka/fishball7010/kernel/zynq_pluto_linux_mini_defconfig
+++ b/board/tezuka/fishball7010/kernel/zynq_pluto_linux_mini_defconfig
@@ -200,10 +200,14 @@ CONFIG_SPI_CADENCE=y
 CONFIG_SPI_XILINX=y
 CONFIG_SPI_ZYNQ_QSPI=y
 CONFIG_SPI_SPIDEV=y
-#CONFIG_PPS=y
-#CONFIG_NTP_PPS=y
-#CONFIG_PPS_CLIENT_KTIMER=y
-#CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS=y
+CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS_CLIENT_GPIO=y
+# CONFIG_NTP_PPS (the in-kernel hardpps consumer) is left off: it depends on a
+# periodic kernel (!NO_HZ) which these configs do not run, and chrony reads
+# /dev/pps directly so nothing here needs it.
+# CONFIG_PPS_CLIENT_KTIMER is left off deliberately: it fabricates test pulses,
+# and a /dev/pps that ticks without any GPS attached is a trap, not a feature.
 CONFIG_GPIOLIB=y
 CONFIG_GPIO_SYSFS=y
 CONFIG_GPIO_ZYNQ=y

--- a/board/tezuka/libre/kernel/zynq_pluto_linux_defconfig
+++ b/board/tezuka/libre/kernel/zynq_pluto_linux_defconfig
@@ -198,10 +198,14 @@ CONFIG_SPI_CADENCE=y
 CONFIG_SPI_XILINX=y
 CONFIG_SPI_ZYNQ_QSPI=y
 CONFIG_SPI_SPIDEV=y
-#CONFIG_PPS=y
-#CONFIG_NTP_PPS=y
-#CONFIG_PPS_CLIENT_KTIMER=y
-#CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS=y
+CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS_CLIENT_GPIO=y
+# CONFIG_NTP_PPS (the in-kernel hardpps consumer) is left off: it depends on a
+# periodic kernel (!NO_HZ) which these configs do not run, and chrony reads
+# /dev/pps directly so nothing here needs it.
+# CONFIG_PPS_CLIENT_KTIMER is left off deliberately: it fabricates test pulses,
+# and a /dev/pps that ticks without any GPS attached is a trap, not a feature.
 CONFIG_GPIOLIB=y
 CONFIG_GPIO_SYSFS=y
 CONFIG_GPIO_ZYNQ=y

--- a/board/tezuka/plutoplus/kernel/zynq_pluto_linux_defconfig
+++ b/board/tezuka/plutoplus/kernel/zynq_pluto_linux_defconfig
@@ -177,10 +177,14 @@ CONFIG_SPI_CADENCE=y
 CONFIG_SPI_XILINX=y
 CONFIG_SPI_ZYNQ_QSPI=y
 CONFIG_SPI_SPIDEV=y
-#CONFIG_PPS=y
-#CONFIG_NTP_PPS=y
-#CONFIG_PPS_CLIENT_KTIMER=y
-#CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS=y
+CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS_CLIENT_GPIO=y
+# CONFIG_NTP_PPS (the in-kernel hardpps consumer) is left off: it depends on a
+# periodic kernel (!NO_HZ) which these configs do not run, and chrony reads
+# /dev/pps directly so nothing here needs it.
+# CONFIG_PPS_CLIENT_KTIMER is left off deliberately: it fabricates test pulses,
+# and a /dev/pps that ticks without any GPS attached is a trap, not a feature.
 CONFIG_GPIOLIB=y
 CONFIG_GPIO_SYSFS=y
 CONFIG_GPIO_ZYNQ=y

--- a/board/tezuka/plutoskyr2/kernel/zynq_pluto_linux_defconfig
+++ b/board/tezuka/plutoskyr2/kernel/zynq_pluto_linux_defconfig
@@ -199,10 +199,14 @@ CONFIG_SPI_CADENCE=y
 CONFIG_SPI_XILINX=y
 CONFIG_SPI_ZYNQ_QSPI=y
 CONFIG_SPI_SPIDEV=y
-#CONFIG_PPS=y
-#CONFIG_NTP_PPS=y
-#CONFIG_PPS_CLIENT_KTIMER=y
-#CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS=y
+CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS_CLIENT_GPIO=y
+# CONFIG_NTP_PPS (the in-kernel hardpps consumer) is left off: it depends on a
+# periodic kernel (!NO_HZ) which these configs do not run, and chrony reads
+# /dev/pps directly so nothing here needs it.
+# CONFIG_PPS_CLIENT_KTIMER is left off deliberately: it fabricates test pulses,
+# and a /dev/pps that ticks without any GPS attached is a trap, not a feature.
 CONFIG_GPIOLIB=y
 CONFIG_GPIO_SYSFS=y
 CONFIG_GPIO_ZYNQ=y

--- a/board/tezuka/plutoskyr2/kernel/zynq_pluto_linux_mini_defconfig
+++ b/board/tezuka/plutoskyr2/kernel/zynq_pluto_linux_mini_defconfig
@@ -200,10 +200,14 @@ CONFIG_SPI_CADENCE=y
 CONFIG_SPI_XILINX=y
 CONFIG_SPI_ZYNQ_QSPI=y
 CONFIG_SPI_SPIDEV=y
-#CONFIG_PPS=y
-#CONFIG_NTP_PPS=y
-#CONFIG_PPS_CLIENT_KTIMER=y
-#CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS=y
+CONFIG_PPS_CLIENT_LDISC=y
+CONFIG_PPS_CLIENT_GPIO=y
+# CONFIG_NTP_PPS (the in-kernel hardpps consumer) is left off: it depends on a
+# periodic kernel (!NO_HZ) which these configs do not run, and chrony reads
+# /dev/pps directly so nothing here needs it.
+# CONFIG_PPS_CLIENT_KTIMER is left off deliberately: it fabricates test pulses,
+# and a /dev/pps that ticks without any GPS attached is a trap, not a feature.
 CONFIG_GPIOLIB=y
 CONFIG_GPIO_SYSFS=y
 CONFIG_GPIO_ZYNQ=y


### PR DESCRIPTION
The PPS lines have sat commented in every kernel defconfig since before any board had a pulse to offer (`CONFIG_PPS` itself is already `=y` in practice, selected by `PTP_1588_CLOCK`, but no client driver exists so `/dev/pps*` can never appear). GPS-disciplined boards are now real, so the clients go in, across all ten defconfigs:

- `CONFIG_PPS_CLIENT_LDISC=y` - a PPS on a serial line's DCD, the usual GPS wiring through gpsd;
- `CONFIG_PPS_CLIENT_GPIO=y` - a pulse brought to any GPIO, **including a PL pin routed out through EMIO**, which is how a fabric-side PPS input can be handed to the kernel with no new drivers.

Two of the originally sketched options stay off, each with its reason written into the defconfig rather than left as an omission:

- `CONFIG_NTP_PPS` (the in-kernel hardpps consumer) depends on a periodic kernel (`!NO_HZ`) and these configs are tickless - and chrony reads `/dev/pps` directly, so nothing needs it;
- `CONFIG_PPS_CLIENT_KTIMER` fabricates test pulses, and a `/dev/pps` that ticks with no GPS attached is a trap, not a feature.

Config-only change; the pps-gpio consumer additionally needs a devicetree node naming its pin before a device appears, which is per-board wiring and can follow board by board.