### PR TITLE
classifier: richer per-frame features + gated matching (experimental, WIP)

### DIFF
--- a/Dashboard/classifier.jsx
+++ b/Dashboard/classifier.jsx
@@ -52,6 +52,24 @@ function fmtHz(hz) {
   return Math.round(hz) + ' Hz';
 }
 
+// The daemon publishes "n/a" (a literal string, not a number) for the two
+// cross-cycle features until its rolling history has enough samples — see
+// history_compute() in app/classifier/classifier.c.
+function parseMaybe(v) {
+  if (v == null || v === 'n/a') return null;
+  const n = Number(v);
+  return isFinite(n) ? n : null;
+}
+
+function fmtHzRate(hzPerS) {
+  if (hzPerS == null || !isFinite(hzPerS)) return '—';
+  const sign = hzPerS < 0 ? '-' : '';
+  const abs = Math.abs(hzPerS);
+  if (abs >= 1e6) return sign + (abs / 1e6).toFixed(2) + ' MHz/s';
+  if (abs >= 1e3) return sign + (abs / 1e3).toFixed(1) + ' kHz/s';
+  return sign + Math.round(abs) + ' Hz/s';
+}
+
 function ClassifierPage({ d }) {
   const canvasRef = useRCl(null);
   const binsRef   = useRCl(null);      // Float32Array dB, current live frame
@@ -98,6 +116,25 @@ function ClassifierPage({ d }) {
   // device-side state needed.
   const centerHz = d.rxFreq ?? 100e6;
   const spanHz = d.span ?? d.rxSampling ?? 20e6;
+
+  // Signal Features (experimental): per-frame scalar features + cross-cycle
+  // drift/duty-cycle, published unconditionally by the daemon every ~1s
+  // cycle regardless of match outcome — see extract_frame_features() /
+  // history_compute() in app/classifier/classifier.c. Bin-based values are
+  // converted to Hz using this page's own live /waterfall connection's
+  // current frame length: the daemon doesn't publish a fresh frame_bins
+  // alongside these (only alongside an actual match, where the reading
+  // needs to be exact) — this is an approximation, fine for a display-only
+  // readout, and only ever off if the frame size changed within the last
+  // update cycle.
+  const featureFrameBins = binsRef.current ? binsRef.current.length : null;
+  const toHz = (bins) => (bins == null || !featureFrameBins) ? null : (bins / featureFrameBins) * spanHz;
+  const featureBandwidthHz = toHz(parseMaybe(d.classifierFeatureBandwidthBins));
+  const featureDriftHzS    = toHz(parseMaybe(d.classifierFeatureDriftBinsS));
+  const featurePaprDb      = parseMaybe(d.classifierFeaturePaprDb);
+  const featureFlatness    = parseMaybe(d.classifierFeatureFlatness);
+  const featurePeakCount   = parseMaybe(d.classifierFeaturePeakCount);
+  const featureDutyPct     = parseMaybe(d.classifierFeatureDutyCyclePct);
 
   function redraw() {
     const canvas = canvasRef.current;
@@ -359,6 +396,21 @@ function ClassifierPage({ d }) {
               {e.templateId != null && <span className="dim">#{e.templateId}</span>}
             </div>
           ))}
+        </div>
+      </Card>
+
+      <Card title="Signal Features" sub="Per-frame + rolling scalar features, published every cycle regardless of match" className="span-12"
+        right={<Pill tone="warn">experimental</Pill>}>
+        <div className="mono" style={{ display: 'flex', flexWrap: 'wrap', gap: '4px 5ch' }}>
+          <div><div className="dim" style={{ fontSize: 11 }}>Occupied bandwidth</div><div>{fmtHz(featureBandwidthHz)}</div></div>
+          <div><div className="dim" style={{ fontSize: 11 }}>Peak/average ratio</div><div>{featurePaprDb == null ? '—' : featurePaprDb.toFixed(1) + ' dB'}</div></div>
+          <div><div className="dim" style={{ fontSize: 11 }}>Spectral flatness</div><div>{featureFlatness == null ? '—' : featureFlatness.toFixed(3)}</div></div>
+          <div><div className="dim" style={{ fontSize: 11 }}>Peak count</div><div>{featurePeakCount == null ? '—' : Math.round(featurePeakCount)}</div></div>
+          <div><div className="dim" style={{ fontSize: 11 }}>Drift (peak sweep rate)</div><div>{fmtHzRate(featureDriftHzS)}</div></div>
+          <div><div className="dim" style={{ fontSize: 11 }}>Duty cycle</div><div>{featureDutyPct == null ? '—' : featureDutyPct.toFixed(0) + '%'}</div></div>
+        </div>
+        <div className="dim" style={{ fontSize: 11, marginTop: 10, maxWidth: '70ch' }}>
+          High flatness + low peak/average → broadband/noise-like (e.g. OFDM). Low flatness + high peak/average → tonal (e.g. CW). A non-zero drift means the dominant peak is sweeping — a static single frame can't otherwise show that a signal is a chirp. Duty cycle and drift read "—" until the daemon's rolling history has enough samples (a few seconds after (re)start).
         </div>
       </Card>
 

--- a/Dashboard/classifier.jsx
+++ b/Dashboard/classifier.jsx
@@ -64,7 +64,14 @@ function ClassifierPage({ d }) {
   const [log, setLog] = useSCl([]);          // {t, label, confidence, templateId}
   const lastLoggedRef = useRCl(null);        // dedupe: only log on actual change
 
-  const refDb = 0, range = 100; // fixed display scale — this page isn't a general-purpose analyzer
+  // Fixed display scale — this page isn't a general-purpose analyzer, so it
+  // doesn't expose its own ref/range tuner. Must match the rest of the
+  // Dashboard's default window (pages1.jsx / radioastro.jsx both default to
+  // refDb=130, range=SP_ROWS*10=80): /waterfall's bins are raw-amplitude-to-
+  // dB, not calibrated dBm, so they land around 50-130, not 0..-100. The
+  // previous 0/-100 window clipped every real bin to the top pixel row,
+  // which read as an empty trace.
+  const refDb = 130, range = 80;
 
   // Band plan: fetched once from maia-httpd's static file serving (see
   // S59bandplan — /root/bandplan.json is a symlink to the persistent copy

--- a/Dashboard/data.jsx
+++ b/Dashboard/data.jsx
@@ -123,6 +123,19 @@ function applyMqtt(prev, path, raw) {
     case 'classifier/bandwidth_bins':  return { ...prev, classifierBandwidthBins: raw };
     case 'classifier/frame_bins':      return { ...prev, classifierFrameBins: raw };
     case 'classifier/template_id':     return { ...prev, classifierTemplateId: raw };
+    // Per-frame scalar features (experimental) — published every cycle
+    // regardless of match outcome, so these populate even while
+    // classifierLabel is "unknown". See extract_frame_features() in
+    // app/classifier/classifier.c.
+    case 'classifier/feature_bandwidth_bins': return { ...prev, classifierFeatureBandwidthBins: raw };
+    case 'classifier/feature_papr_db':        return { ...prev, classifierFeaturePaprDb: raw };
+    case 'classifier/feature_flatness':       return { ...prev, classifierFeatureFlatness: raw };
+    case 'classifier/feature_peak_count':     return { ...prev, classifierFeaturePeakCount: raw };
+    // Cross-cycle features (experimental) — "n/a" (a literal string, not a
+    // number) until the daemon's rolling history has enough samples; see
+    // history_compute() in app/classifier/classifier.c.
+    case 'classifier/feature_drift_bins_s':     return { ...prev, classifierFeatureDriftBinsS: raw };
+    case 'classifier/feature_duty_cycle_pct':   return { ...prev, classifierFeatureDutyCyclePct: raw };
     case 'operator/name':               return { ...prev, opName: raw };
     case 'operator/callsign':           return { ...prev, opCallsign: raw };
     case 'operator/locator':            return { ...prev, opLocator: raw };

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 * **Risk-Free Booting:** Built-in **SD Card boot support** for effortless updates with zero risk of bricking your flash memory.
 * **Integrated Apps:** Includes Maia-SDR transparently, fast sweep, and MQTT status publishing and more.
 * **Remote Access:** Built-in WireGuard VPN, configured from the Dashboard by pasting a `wg-quick` config — no SSH/CLI needed.
-* **Signal Classifier:** Onboard PSD spectral-shape matching identifies signal types live, overlaid right on the Dashboard's spectrum view.
+* **Signal Classifier (experimental):** Onboard PSD spectral-shape matching identifies signal types live, overlaid right on the Dashboard's spectrum view. Work in progress — not yet validated on real hardware.
 
 ---
 
@@ -92,18 +92,29 @@ Connect your board to a remote WireGuard server for secure remote access, config
 
 **Security note:** the pasted config is sent once and never redisplayed or echoed back over MQTT. That said, the Dashboard's default MQTT channel (port 9001) is unauthenticated on the local network by design, same as every other Dashboard control — treat the WireGuard private key like any other credential on an open network segment, and avoid exposing the device's management interface to untrusted networks.
 
-### Signal Classifier
+### Signal Classifier (experimental, work in progress)
 
-Onboard PSD spectral-shape matching — identifies signal *types* (OFDM, FSK, chirp, CW, etc.) live and overlays a label on the spectrum, right on the device, no host-side processing required:
+> **Status:** experimental. The pipeline is cross-compiled and exercised under `qemu-arm-static`, and the correlation math is unit-tested directly, but it has not yet been run end-to-end against a real signal on real hardware — see [Known limitations](#known-limitations) below before relying on it for anything.
 
-* Open the Dashboard's **Signal Classifier** page (under RF) and toggle **Enabled** — it runs as a background service, correlating the live spectrum against a set of loaded templates roughly once a second.
-* A matched signal gets a label chip (e.g. "OFDM · 92%") overlaid on its own live spectrum view, plus a reference-match panel showing the live shape against the matched template, and a scrolling log of recent classifications.
-* Ships with a small starter set out of the box (FM broadcast, DAB+, CW/beacon — synthesized canonical shapes, seeded on first boot) so there's something to test against immediately. Templates are built offline (see `tools/classifier_templates/`, including a script to bootstrap templates directly from a live device — no GNU Radio/TorchSig install required for a first test) and pushed to the device the same way a WireGuard config is: base64 over MQTT (`cmd/classifier/templates`), which replaces the starter set permanently.
-* Below the confidence threshold, or with no templates loaded, the classifier reports "unknown" rather than forcing a guess.
+Onboard PSD spectral-shape matching — identifies signal *types* (OFDM, FSK, chirp, CW, etc.) live and overlays a label on the spectrum, right on the device, no host-side processing required.
 
-This is spectral-*shape* matching (magnitude/PSD correlation), not true cyclostationary SCF — it separates signal types well but won't reliably distinguish modulation order within a family (e.g. BPSK vs. QPSK). It reuses the same live FFT feed the Spectrum and Radio Astronomy pages already consume (`maia-httpd`'s `/waterfall`), so it adds no new consumer of the ADC and never competes with IQ Tape or the Signal Generator.
+**How it works:** a small daemon (`app/classifier/classifier.c`) connects as a WebSocket client to `maia-httpd`'s existing `/waterfall` feed — the same live FFT the Spectrum and Radio Astronomy pages already consume — and correlates each frame against a set of loaded templates roughly once a second, publishing the best match over MQTT. It never touches the raw-IQ path (`iio_ws_proxy`), so it adds no new consumer of the ADC and never competes with IQ Tape or the Signal Generator. This is spectral-*shape* matching (magnitude/PSD cosine similarity), not true cyclostationary SCF — it separates signal families well but won't reliably distinguish modulation order within a family (e.g. BPSK vs. QPSK), since that distinction lives in phase information this feed doesn't carry.
+
+**Sample rate:** no special sample rate is required — the daemon adapts to whatever bin count `/waterfall` is currently emitting. One real caveat: matching is relative-bin shape correlation, not Hz-normalized, so a template captured (or synthesized) at one span will transfer poorly to classifying live at a very different span. Build templates at roughly the span you plan to classify at.
+
+**Using it:**
+
+* Open the Dashboard's **Signal Classifier** page (under RF) and toggle **Enabled** — it runs as a background service from then on.
+* A matched signal gets a label chip (e.g. "OFDM · 92%") overlaid on its own live spectrum view, plus a "Reference match" panel and a scrolling log of recent classifications. Below the confidence threshold, or with no templates loaded, it reports "unknown" rather than forcing a guess.
+* Ships with a small starter set out of the box (FM broadcast, DAB+, CW/beacon — synthesized canonical shapes, seeded on first boot) so there's something to test against immediately. Build your own with `tools/classifier_templates/` — either `capture_from_device.py` (pulls a shape straight off a live device, no GNU Radio/TorchSig required) or `synthesize_template.py` (idealized canonical shapes for classes you can't easily capture yet) — and push the result the same way a WireGuard config is sent: base64 over MQTT (`cmd/classifier/templates`), which replaces the starter set permanently.
 
 The same page also shows a **band plan** — a color-coded strip under the spectrum marking known allocations (broadcast, cellular, aviation, maritime, etc.), independent of whether the classifier has actually matched anything there. Click a swatch (or a row in the editable table below it) to tune to that frequency. Entries are stored on the device (`/mnt/jffs2/bandplan.json`, seeded from a starting reference table) and edited directly from the Dashboard — add, edit, or remove entries and hit **Save**.
+
+#### Known limitations
+
+* **Not yet validated on real hardware.** Everything so far is cross-compiled and run under `qemu-arm-static`, plus unit tests on the correlation math — the full `/waterfall` → correlate → MQTT → Dashboard path hasn't had a live-signal pass yet.
+* The "Reference match" panel currently shows the live captured shape only, labeled with the matched template's name — it doesn't overlay the stored template curve itself, since the raw template data lives only in the daemon's binary file and isn't published to the Dashboard.
+* PSD shape matching won't distinguish modulation order within a family (see above).
 
 ---
 

--- a/app/classifier/classifier.c
+++ b/app/classifier/classifier.c
@@ -21,13 +21,34 @@
  * Template file format (little-endian, shared with the offline
  * tools/classifier_templates generator):
  *   char     magic[4]      = "SCFT"
- *   uint32_t version       = 1
+ *   uint32_t version       = 1 or 2
  *   uint32_t count
  *   uint32_t canonical_n
  *   then `count` entries of:
  *     char     label[32]   (NUL-padded, truncated if longer)
  *     uint32_t template_id
  *     float    data[canonical_n]   (pre-normalized: zero-mean, unit L2 norm)
+ *     -- version 2 only, appended per entry --
+ *     float    bandwidth_frac_lo, bandwidth_frac_hi
+ *     float    papr_db_lo,        papr_db_hi
+ *     float    flatness_lo,       flatness_hi
+ *     float    peak_count_lo,     peak_count_hi
+ *   (a range with hi < lo means "unbounded" — no gate on that feature;
+ *   version 1 files are loaded as if every range were unbounded, so old
+ *   templates.bin files still classify exactly as before)
+ *
+ * Beyond the shape-correlation score, each frame's scalar features
+ * (occupied bandwidth, peak-to-average ratio, spectral flatness, local
+ * peak count — see extract_frame_features()) are published every cycle
+ * regardless of match outcome, plus two cross-cycle features tracked in a
+ * short rolling history (see history_push()/history_compute()): peak-bin
+ * drift (catches a genuinely sweeping/chirping carrier, which a single
+ * static frame can't show) and duty cycle (catches bursty/pulsed
+ * emitters). A version-2 template can also declare expected ranges for
+ * the four per-frame features; classify() then applies those as a soft
+ * penalty on top of the shape score (see template_gate_factor()), so two
+ * classes with a similar curve but different real bandwidth/peakiness
+ * can still be told apart.
  *
  * Build (cross-compile for Pluto):
  * $(CC) -O2 -o classifier classifier.c -lwebsockets -lm
@@ -62,10 +83,20 @@
 /* ------------------------------------------------------------------ */
 /* Templates                                                           */
 /* ------------------------------------------------------------------ */
+
+/* A range with hi < lo means "unbounded" (no gate on this feature) — the
+ * default for every field on a version-1 template. */
+struct feature_range { float lo, hi; };
+
 struct template {
     char     label[32];
     uint32_t id;
     float   *data;   /* canonical_n floats, pre-normalized (zero-mean, unit L2 norm) */
+
+    /* version 2 only; has_gate is false (all ranges unbounded) for
+     * version-1 files, which then behave exactly as before. */
+    bool     has_gate;
+    struct feature_range bandwidth_frac, papr_db, flatness, peak_count;
 };
 
 struct templates {
@@ -100,7 +131,7 @@ static int templates_load(const char *path, struct templates *t)
         fclose(f);
         return -1;
     }
-    if (fread(&version, sizeof(version), 1, f) != 1 || version != 1) {
+    if (fread(&version, sizeof(version), 1, f) != 1 || (version != 1 && version != 2)) {
         fprintf(stderr, "templates: unsupported version in %s\n", path);
         fclose(f);
         return -1;
@@ -126,6 +157,18 @@ static int templates_load(const char *path, struct templates *t)
         if (!items[i].data) goto fail;
         if (fread(items[i].data, sizeof(float), canonical_n, f) != canonical_n)
             goto fail;
+
+        if (version >= 2) {
+            float ranges[8];
+            if (fread(ranges, sizeof(float), 8, f) != 8) goto fail;
+            items[i].has_gate       = true;
+            items[i].bandwidth_frac = (struct feature_range){ ranges[0], ranges[1] };
+            items[i].papr_db        = (struct feature_range){ ranges[2], ranges[3] };
+            items[i].flatness       = (struct feature_range){ ranges[4], ranges[5] };
+            items[i].peak_count     = (struct feature_range){ ranges[6], ranges[7] };
+        } else {
+            items[i].has_gate = false; /* v1: no gate at all, ranges are never consulted */
+        }
         continue;
 fail:
         fprintf(stderr, "templates: truncated/corrupt %s\n", path);
@@ -195,6 +238,131 @@ static double cosine_sim(const float *a, const float *b, uint32_t n)
     return s;
 }
 
+/* ------------------------------------------------------------------ */
+/* Frame features — scalar descriptors of a single live frame, computed
+ * once per cycle from the RAW linear-amplitude bins (before normalize()
+ * mean-centers them, which would make these power ratios meaningless).
+ * Published every cycle regardless of match outcome (see
+ * publish_features()) and, for a version-2 template, also used to gate
+ * the shape score (see template_gate_factor()). */
+/* ------------------------------------------------------------------ */
+struct frame_features {
+    bool     valid;         /* false if the frame had ~no energy at all */
+    double   bandwidth_frac;/* -10 dB occupied width, as a fraction of the frame */
+    double   papr_db;       /* peak-to-average power ratio */
+    double   flatness;      /* spectral flatness (geomean/mean of power), in (0, 1] */
+    double   peak_count;    /* number of locally-prominent maxima */
+    uint32_t peak_bin;      /* index of the global peak */
+};
+
+/* Cross-cycle features from history_compute() — see the rolling
+ * `history[]` ring in struct app. Both fields are "n/a" (valid=false)
+ * until the ring has enough samples spanning enough real time; no
+ * spurious estimates right after the daemon (re)starts. */
+struct temporal_features {
+    bool     drift_valid;
+    double   drift_bins_per_s; /* + = peak moving toward higher bins over time */
+    bool     duty_valid;
+    double   duty_cycle_pct;   /* % of recent cycles with a standout peak present */
+};
+
+/* -10 dB occupied bandwidth is found by scanning outward from the peak
+ * until power drops below peak/10, not a global threshold count — that
+ * stays robust to a stray unrelated noise bin elsewhere in the frame. */
+#define BW_GATE_RATIO      0.1   /* -10 dB */
+/* A candidate peak must be within this ratio of the global peak to count
+ * for peak_count — otherwise every noise wiggle would count. */
+#define PEAK_PROMINENCE_RATIO 0.0316 /* -15 dB */
+
+static struct frame_features extract_frame_features(const float *raw, uint32_t n)
+{
+    struct frame_features ff;
+    memset(&ff, 0, sizeof(ff));
+    if (n == 0) return ff;
+
+    uint32_t peak_i = 0;
+    double peak_amp = raw[0] > 0 ? raw[0] : 0.0;
+    double sum_power = 0.0, sum_log_power = 0.0;
+    for (uint32_t i = 0; i < n; i++) {
+        double amp = raw[i] > 0 ? raw[i] : 0.0;
+        double power = amp * amp;
+        sum_power     += power;
+        sum_log_power += log(power > 1e-20 ? power : 1e-20);
+        if (amp > peak_amp) { peak_amp = amp; peak_i = i; }
+    }
+    if (peak_amp <= 0.0 || sum_power <= 0.0) return ff; /* leaves valid=false */
+
+    double peak_power = peak_amp * peak_amp;
+    double mean_power = sum_power / n;
+
+    ff.papr_db  = 10.0 * log10(peak_power / (mean_power > 1e-20 ? mean_power : 1e-20));
+    double geomean_power = exp(sum_log_power / n);
+    ff.flatness = geomean_power / (mean_power > 1e-20 ? mean_power : 1e-20);
+    if (ff.flatness > 1.0) ff.flatness = 1.0; /* numerical guard: should be <=1 by AM-GM */
+
+    double bw_gate = peak_power * BW_GATE_RATIO;
+    uint32_t lo = peak_i, hi = peak_i;
+    while (lo > 0     && (double)raw[lo - 1] * raw[lo - 1] >= bw_gate) lo--;
+    while (hi + 1 < n && (double)raw[hi + 1] * raw[hi + 1] >= bw_gate) hi++;
+    ff.bandwidth_frac = (double)(hi - lo + 1) / (double)n;
+
+    /* Local maxima above a fixed prominence floor, deduped by a minimum
+     * bin separation (n/64, at least 1) — a lightweight heuristic, not a
+     * proper prominence-based peak detector, but enough to tell "one
+     * carrier" from "a comb of several" in a single pass. */
+    double prom_gate = peak_power * PEAK_PROMINENCE_RATIO;
+    uint32_t min_sep = n / 64 > 1 ? n / 64 : 1;
+    uint32_t count = 0, last_peak = 0;
+    bool have_last = false;
+    for (uint32_t i = 1; i + 1 < n; i++) {
+        double p = (double)raw[i] * raw[i];
+        if (p < prom_gate) continue;
+        if (raw[i] <= raw[i - 1] || raw[i] <= raw[i + 1]) continue;
+        if (have_last && (i - last_peak) < min_sep) continue;
+        count++;
+        last_peak = i;
+        have_last = true;
+    }
+    ff.peak_count = (double)count;
+
+    ff.peak_bin = peak_i;
+    ff.valid = true;
+    return ff;
+}
+
+/* Soft penalty in (0, 1] for how well `ff` matches a version-2 template's
+ * declared expected ranges. A hard reject at the boundary would be
+ * brittle — real-world noise sits right there — so this steps down a
+ * bounded amount per out-of-range feature instead of rejecting outright,
+ * keeping the ranking well-behaved while still letting a badly-mismatched
+ * feature (wrong bandwidth by a wide margin, say) push a shape-similar-
+ * but-wrong template below a better-gated competitor. Templates without a
+ * gate (v1, or a v2 entry with every range left unbounded) always return
+ * 1.0 — no effect on their score. */
+/* Four gated features (bandwidth/PAPR/flatness/peak_count) at 0.15 each
+ * means missing all four lands exactly at the floor (1.0 - 4*0.15 = 0.4) —
+ * chosen together so the floor is an actual reachable bound, not a dead
+ * constant a smaller per-feature penalty would never hit. */
+#define GATE_PENALTY_PER_FEATURE 0.15
+#define GATE_PENALTY_FLOOR       0.4
+
+static double range_miss(double v, struct feature_range r)
+{
+    if (r.hi < r.lo) return 0.0; /* unbounded: no penalty */
+    return (v >= r.lo && v <= r.hi) ? 0.0 : 1.0;
+}
+
+static double template_gate_factor(const struct template *tpl, const struct frame_features *ff)
+{
+    if (!tpl->has_gate || !ff->valid) return 1.0;
+    double misses = range_miss(ff->bandwidth_frac, tpl->bandwidth_frac)
+                  + range_miss(ff->papr_db,        tpl->papr_db)
+                  + range_miss(ff->flatness,       tpl->flatness)
+                  + range_miss(ff->peak_count,     tpl->peak_count);
+    double factor = 1.0 - misses * GATE_PENALTY_PER_FEATURE;
+    return factor < GATE_PENALTY_FLOOR ? GATE_PENALTY_FLOOR : factor;
+}
+
 struct match_result {
     bool     found;
     uint32_t template_idx;
@@ -207,8 +375,15 @@ struct match_result {
  * loaded template. If a template is narrower than the live frame, slides
  * it across all valid start positions and keeps the best-scoring one
  * (re-normalizing each window, since a raw sub-slice of an
- * already-whole-frame-normalized vector isn't itself unit-norm). */
-static struct match_result classify(const float *live, uint32_t live_n, const struct templates *t)
+ * already-whole-frame-normalized vector isn't itself unit-norm).
+ *
+ * `ff` is the live frame's own scalar features (see extract_frame_features)
+ * — used only for gating a version-2 template's score (template_gate_factor),
+ * the same frame-level ff for every candidate window rather than
+ * recomputing per-window, which would be considerably more expensive for
+ * a gate that's meant to be a coarse sanity check, not a second matcher. */
+static struct match_result classify(const float *live, uint32_t live_n, const struct templates *t,
+                                     const struct frame_features *ff)
 {
     struct match_result best = { .found = false, .score = -2.0 };
     if (!t->items || t->count == 0) return best;
@@ -219,6 +394,7 @@ static struct match_result classify(const float *live, uint32_t live_n, const st
 
     for (uint32_t ti = 0; ti < t->count; ti++) {
         const struct template *tpl = &t->items[ti];
+        double gate = template_gate_factor(tpl, ff);
 
         if (tn >= live_n) {
             /* Template is at least as wide as the live frame: resample
@@ -228,7 +404,7 @@ static struct match_result classify(const float *live, uint32_t live_n, const st
             if (!resampled) continue;
             resample_linear(live, live_n, resampled, tn);
             if (normalize(resampled, tn)) {
-                double s = cosine_sim(resampled, tpl->data, tn);
+                double s = cosine_sim(resampled, tpl->data, tn) * gate;
                 if (s > best.score) {
                     best.found = true;
                     best.template_idx = ti;
@@ -247,7 +423,7 @@ static struct match_result classify(const float *live, uint32_t live_n, const st
         for (uint32_t start = 0; start + tn <= live_n; start++) {
             memcpy(window, live + start, tn * sizeof(float));
             if (!normalize(window, tn)) continue;
-            double s = cosine_sim(window, tpl->data, tn);
+            double s = cosine_sim(window, tpl->data, tn) * gate;
             if (s > best.score) {
                 best.found = true;
                 best.template_idx = ti;
@@ -287,6 +463,22 @@ struct app {
     bool        locked;
     uint32_t    locked_template_id;
 
+    /* Rolling history of recent peak positions, for the two cross-cycle
+     * features a single frame can't show on its own (see history_push() /
+     * history_compute()): peak-bin drift (a genuinely sweeping/chirping
+     * carrier) and duty cycle (a bursty/pulsed emitter). A fixed-size ring
+     * covering FEATURE_HISTORY cycles at the ~1/s throttle rate below —
+     * about 16s of history by default, plenty for both without unbounded
+     * growth. */
+    struct {
+        double   t;             /* seconds since start_time */
+        double   peak_bin_frac; /* 0..1, scale-invariant across frame-size changes */
+        bool     occupied;
+    } history[16];
+    uint32_t history_next;
+    uint32_t history_filled;
+    struct timespec start_time;
+
     /* Per-connection message reassembly buffer (WS fragments can arrive
      * across multiple RECEIVE callbacks; browsers hide this, raw lws
      * doesn't) */
@@ -298,6 +490,8 @@ struct app {
     volatile bool running;
     volatile bool connected;   /* set true on ESTABLISHED, false on CLOSED/ERROR */
 };
+
+#define FEATURE_HISTORY ((uint32_t)(sizeof(((struct app *)0)->history) / sizeof(((struct app *)0)->history[0])))
 
 static struct app A;
 
@@ -373,6 +567,51 @@ static void publish_result(struct app *a, const struct match_result *r, const st
                 tpl->label, tpl->id, r->score, r->bin_offset);
 }
 
+/* Published every cycle regardless of match outcome — these describe the
+ * live signal itself, not a match against a template, so they're useful
+ * even when nothing matched ("unknown, but here's what we can tell about
+ * it"). bandwidth is reported in bins (matching the existing
+ * bandwidth_bins convention for an actual match) so the Dashboard can
+ * convert it to Hz with the same math it already has. */
+static void publish_features(const struct frame_features *ff, uint32_t live_n)
+{
+    char buf[64];
+    if (!ff->valid) {
+        mqtt_pub("feature_bandwidth_bins", "0");
+        mqtt_pub("feature_papr_db", "0.0");
+        mqtt_pub("feature_flatness", "0.0");
+        mqtt_pub("feature_peak_count", "0");
+        return;
+    }
+    snprintf(buf, sizeof(buf), "%u", (uint32_t)(ff->bandwidth_frac * live_n + 0.5));
+    mqtt_pub("feature_bandwidth_bins", buf);
+    snprintf(buf, sizeof(buf), "%.2f", ff->papr_db);
+    mqtt_pub("feature_papr_db", buf);
+    snprintf(buf, sizeof(buf), "%.4f", ff->flatness);
+    mqtt_pub("feature_flatness", buf);
+    snprintf(buf, sizeof(buf), "%u", (uint32_t)ff->peak_count);
+    mqtt_pub("feature_peak_count", buf);
+}
+
+/* "n/a" (not a number the Dashboard should try to parse) until the history
+ * ring has enough samples — see history_compute(). */
+static void publish_temporal(const struct temporal_features *tf)
+{
+    char buf[64];
+    if (tf->duty_valid) {
+        snprintf(buf, sizeof(buf), "%.1f", tf->duty_cycle_pct);
+        mqtt_pub("feature_duty_cycle_pct", buf);
+    } else {
+        mqtt_pub("feature_duty_cycle_pct", "n/a");
+    }
+    if (tf->drift_valid) {
+        snprintf(buf, sizeof(buf), "%.3f", tf->drift_bins_per_s);
+        mqtt_pub("feature_drift_bins_s", buf);
+    } else {
+        mqtt_pub("feature_drift_bins_s", "n/a");
+    }
+}
+
 /* ------------------------------------------------------------------ */
 /* WebSocket client                                                    */
 /* ------------------------------------------------------------------ */
@@ -393,6 +632,68 @@ static double elapsed_since(const struct timespec *then)
     return (now.tv_sec - then->tv_sec) + (now.tv_nsec - then->tv_nsec) / 1e9;
 }
 
+/* A frame counts as "occupied" (something standing out from the noise
+ * floor, not just thermal noise) once its peak-to-average ratio clears
+ * this floor. A heuristic, not a calibrated detector — same spirit as the
+ * synthetic template shapes in tools/classifier_templates already being
+ * documented idealizations rather than physically calibrated. */
+#define OCCUPIED_PAPR_DB 6.0
+
+/* Minimum ring-buffer occupancy/time-span before history_compute() will
+ * report an actual number instead of "n/a" — avoids a spurious slope
+ * estimate from 2-3 samples right after (re)start. */
+#define HISTORY_MIN_SAMPLES 4
+#define HISTORY_MIN_SPAN_S  3.0
+
+static void history_push(struct app *a, double t, double peak_bin_frac, bool occupied)
+{
+    uint32_t idx = a->history_next % FEATURE_HISTORY;
+    a->history[idx].t             = t;
+    a->history[idx].peak_bin_frac = peak_bin_frac;
+    a->history[idx].occupied      = occupied;
+    a->history_next++;
+    if (a->history_filled < FEATURE_HISTORY) a->history_filled++;
+}
+
+/* Regression runs in fractional-bin space (0..1), not raw bin indices —
+ * that stays valid even if live_n happened to change mid-history (e.g. a
+ * /waterfall FFT-size change), then gets scaled to bins/s using the
+ * *current* live_n only at the end, for the reader. */
+static struct temporal_features history_compute(const struct app *a, uint32_t live_n)
+{
+    struct temporal_features out;
+    memset(&out, 0, sizeof(out));
+    uint32_t n = a->history_filled;
+    if (n < HISTORY_MIN_SAMPLES) return out;
+
+    double t0 = a->history[0].t;
+    double sum_t = 0, sum_y = 0, sum_tt = 0, sum_ty = 0;
+    double t_min = 1e300, t_max = -1e300;
+    uint32_t occupied_count = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        double t = a->history[i].t - t0;
+        double y = a->history[i].peak_bin_frac;
+        sum_t += t; sum_y += y; sum_tt += t * t; sum_ty += t * y;
+        if (t < t_min) t_min = t;
+        if (t > t_max) t_max = t;
+        if (a->history[i].occupied) occupied_count++;
+    }
+
+    out.duty_valid     = true;
+    out.duty_cycle_pct = 100.0 * occupied_count / n;
+
+    double span = t_max - t_min;
+    if (span >= HISTORY_MIN_SPAN_S) {
+        double denom = (double)n * sum_tt - sum_t * sum_t;
+        if (fabs(denom) > 1e-9) {
+            double slope_frac_per_s = ((double)n * sum_ty - sum_t * sum_y) / denom;
+            out.drift_valid       = true;
+            out.drift_bins_per_s  = slope_frac_per_s * (double)live_n;
+        }
+    }
+    return out;
+}
+
 static void handle_frame(struct app *a, const float *f, size_t n_floats)
 {
     if (n_floats < 2) return; /* need at least the step index + 1 bin */
@@ -406,16 +707,30 @@ static void handle_frame(struct app *a, const float *f, size_t n_floats)
     if (!live) return;
     memcpy(live, f + 1, live_n * sizeof(float));
 
+    /* Features come from the RAW copy, before normalize() mean-centers it
+     * below — and are published unconditionally, whether or not anything
+     * ends up matching. */
+    struct frame_features ff = extract_frame_features(live, live_n);
+    publish_features(&ff, live_n);
+
+    double t_now = elapsed_since(&a->start_time);
+    double peak_bin_frac = ff.valid && live_n > 1 ? (double)ff.peak_bin / (double)(live_n - 1) : 0.0;
+    bool occupied = ff.valid && ff.papr_db >= OCCUPIED_PAPR_DB;
+    history_push(a, t_now, peak_bin_frac, occupied);
+    struct temporal_features tf = history_compute(a, live_n);
+    publish_temporal(&tf);
+
     if (!normalize(live, live_n)) {
         /* No energy in this frame at all — publish unknown rather than
          * a meaningless correlation against noise. */
         mqtt_pub("label", "unknown");
         mqtt_pub("confidence", "0.0");
+        a->locked = false;
         free(live);
         return;
     }
 
-    struct match_result r = classify(live, live_n, &a->templates);
+    struct match_result r = classify(live, live_n, &a->templates, &ff);
     publish_result(a, &r, &a->templates, live_n);
     free(live);
 }
@@ -520,6 +835,8 @@ int main(int argc, char **argv)
 
     signal(SIGINT,  on_signal);
     signal(SIGTERM, on_signal);
+
+    clock_gettime(CLOCK_MONOTONIC, &A.start_time);
 
     if (templates_load(A.templates_path, &A.templates) != 0)
         fprintf(stderr, "classifier: no templates loaded yet (%s) — will publish \"unknown\" until "

--- a/app/classifier/classifier.c
+++ b/app/classifier/classifier.c
@@ -39,6 +39,9 @@
  * -P PATH   waterfall WS path        (default: /waterfall)
  * -f FILE   templates file           (default: /mnt/jffs2/classifier/templates.bin)
  * -c THRESH match confidence floor   (default: 0.6, below this publishes "unknown")
+ * -m MARGIN hysteresis hold margin   (default: 0.15 — once locked onto a
+ *           template, only drops back to "unknown" below THRESH - MARGIN,
+ *           so a borderline score doesn't flip found/unknown every cycle)
  * -i SEC    min seconds between correlate+publish cycles (default: 1.0)
  * -v        verbose (log every publish to stderr too)
  */
@@ -262,6 +265,43 @@ static struct match_result classify(const float *live, uint32_t live_n, const st
 }
 
 /* ------------------------------------------------------------------ */
+/* App state (moved ahead of publish_result below, which needs the full
+ * definition for its hysteresis bookkeeping — the WebSocket client code
+ * further down that owns the rest of this struct's fields follows later) */
+/* ------------------------------------------------------------------ */
+struct app {
+    struct templates templates;
+    const char *templates_path;
+    double      threshold;
+    double      hold_margin;
+    double      min_interval_s;
+    bool        verbose;
+
+    /* Hysteresis state: without this, a score that hovers right at
+     * `threshold` flips found/unknown on essentially every ~1s publish
+     * cycle (each cycle is evaluated from scratch, with no memory of the
+     * last one) — visible on the Dashboard as the label chip and the
+     * reference-match panel blinking in and out once a second. Once
+     * locked onto a template, we only drop back to "unknown" if the score
+     * falls below (threshold - hold_margin), not merely below threshold. */
+    bool        locked;
+    uint32_t    locked_template_id;
+
+    /* Per-connection message reassembly buffer (WS fragments can arrive
+     * across multiple RECEIVE callbacks; browsers hide this, raw lws
+     * doesn't) */
+    uint8_t  *msg_buf;
+    size_t    msg_len;
+    size_t    msg_cap;
+
+    struct timespec last_run;
+    volatile bool running;
+    volatile bool connected;   /* set true on ESTABLISHED, false on CLOSED/ERROR */
+};
+
+static struct app A;
+
+/* ------------------------------------------------------------------ */
 /* MQTT publish (shells out to mosquitto_pub, matching the convention
  * already used throughout board/tezuka/common/overlay_tezuka/root/
  * api_controller.sh — publishes here are throttled to ~1/s, so the
@@ -282,12 +322,31 @@ static void mqtt_pub(const char *topic, const char *value)
  * assumed shared knowledge: it's what those two are measured in units
  * of, and publishing it removes any need for a subscriber (the
  * Dashboard) to assume its own /waterfall connection saw the exact same
- * frame size the daemon did at this instant. */
-static void publish_result(const struct match_result *r, const struct templates *t, uint32_t live_n, double threshold, bool verbose)
+ * frame size the daemon did at this instant.
+ *
+ * Hysteresis (a->locked / a->locked_template_id): a borderline score that
+ * sits right around `threshold` would otherwise cross it in either
+ * direction on essentially every ~1s cycle, publishing found/"unknown"
+ * alternately — visible on the Dashboard as the label chip and reference-
+ * match panel blinking every second. Once locked onto a template id, we
+ * only let go if the score for that same template drops below
+ * (threshold - hold_margin); a clearly-better match for a *different*
+ * template still overrides immediately. */
+static void publish_result(struct app *a, const struct match_result *r, const struct templates *t, uint32_t live_n)
 {
     char buf[64];
+    double threshold = a->threshold;
+    bool verbose = a->verbose;
 
-    if (!r->found || r->score < threshold) {
+    bool accept = r->found && r->score >= threshold;
+    if (!accept && a->locked && r->found &&
+        r->template_idx < t->count && t->items[r->template_idx].id == a->locked_template_id &&
+        r->score >= threshold - a->hold_margin) {
+        accept = true; /* holding the existing lock through a brief dip */
+    }
+
+    if (!accept) {
+        a->locked = false;
         mqtt_pub("label", "unknown");
         mqtt_pub("confidence", "0.0");
         if (verbose) fprintf(stderr, "classify: unknown (best=%.3f)\n", r->found ? r->score : 0.0);
@@ -295,6 +354,8 @@ static void publish_result(const struct match_result *r, const struct templates 
     }
 
     const struct template *tpl = &t->items[r->template_idx];
+    a->locked = true;
+    a->locked_template_id = tpl->id;
     mqtt_pub("label", tpl->label);
     snprintf(buf, sizeof(buf), "%.3f", r->score);
     mqtt_pub("confidence", buf);
@@ -315,26 +376,6 @@ static void publish_result(const struct match_result *r, const struct templates 
 /* ------------------------------------------------------------------ */
 /* WebSocket client                                                    */
 /* ------------------------------------------------------------------ */
-struct app {
-    struct templates templates;
-    const char *templates_path;
-    double      threshold;
-    double      min_interval_s;
-    bool        verbose;
-
-    /* Per-connection message reassembly buffer (WS fragments can arrive
-     * across multiple RECEIVE callbacks; browsers hide this, raw lws
-     * doesn't) */
-    uint8_t  *msg_buf;
-    size_t    msg_len;
-    size_t    msg_cap;
-
-    struct timespec last_run;
-    volatile bool running;
-    volatile bool connected;   /* set true on ESTABLISHED, false on CLOSED/ERROR */
-};
-
-static struct app A;
 
 static void ensure_msg_cap(struct app *a, size_t need)
 {
@@ -375,7 +416,7 @@ static void handle_frame(struct app *a, const float *f, size_t n_floats)
     }
 
     struct match_result r = classify(live, live_n, &a->templates);
-    publish_result(&r, &a->templates, live_n, a->threshold, a->verbose);
+    publish_result(a, &r, &a->templates, live_n);
     free(live);
 }
 
@@ -441,6 +482,9 @@ static void usage(const char *prog)
         "  -P PATH   waterfall WS path      (default: /waterfall)\n"
         "  -f FILE   templates file         (default: /mnt/jffs2/classifier/templates.bin)\n"
         "  -c THRESH match confidence floor (default: 0.6)\n"
+        "  -m MARGIN hysteresis hold margin (default: 0.15; holds a lock until\n"
+        "            score < THRESH - MARGIN, so a borderline score doesn't\n"
+        "            flip found/unknown every cycle)\n"
         "  -i SEC    min correlate interval (default: 1.0)\n"
         "  -v        verbose\n"
         "  -h        this help\n", prog);
@@ -453,17 +497,20 @@ int main(int argc, char **argv)
     const char *path = "/waterfall";
     A.templates_path = "/mnt/jffs2/classifier/templates.bin";
     A.threshold       = 0.6;
+    A.hold_margin     = 0.15;
     A.min_interval_s  = 1.0;
     A.verbose         = false;
+    A.locked          = false;
 
     int opt;
-    while ((opt = getopt(argc, argv, "H:p:P:f:c:i:vh")) != -1) {
+    while ((opt = getopt(argc, argv, "H:p:P:f:c:m:i:vh")) != -1) {
         switch (opt) {
         case 'H': host              = optarg;      break;
         case 'p': port              = atoi(optarg); break;
         case 'P': path              = optarg;      break;
         case 'f': A.templates_path  = optarg;      break;
         case 'c': A.threshold       = atof(optarg); break;
+        case 'm': A.hold_margin     = atof(optarg); break;
         case 'i': A.min_interval_s  = atof(optarg); break;
         case 'v': A.verbose         = true;         break;
         case 'h': usage(argv[0]); return 0;

--- a/tools/classifier_templates/README.md
+++ b/tools/classifier_templates/README.md
@@ -80,6 +80,40 @@ GNU Radio/TorchSig setup you're targeting); `templates_format.py`'s
 `Template`/`write_templates` are the integration point once you have PSD
 arrays from your own flowgraphs.
 
+## Feature-gated matching (experimental, work in progress)
+
+Beyond the shape-correlation score, both generator scripts now compute four
+scalar features per template — occupied bandwidth, peak-to-average ratio,
+spectral flatness, and local peak count (`features.py`, kept in lockstep
+with `classifier.c`'s `extract_frame_features()`) — and write them as an
+expected range into a version-2 `templates.bin`. On-device, `classify()`
+uses that range as a *soft* penalty on top of the shape score (see
+`template_gate_factor()` in `classifier.c`), so two classes with a similar
+curve but different real bandwidth or peakiness can still be told apart.
+
+- `synthesize_template.py` derives the range from the one idealized curve it
+  generates, widened generously (`--gate-margin`, default `0.25`) since it's
+  a single synthetic sample, not several real captures.
+- `capture_from_device.py` derives it from the actual spread *across* the
+  captured frames it already grabs (min/max, widened a bit further —
+  `--gate-margin`, default `0.15`) — genuinely data-driven, since it already
+  has several live samples to work with.
+- Pass `--no-gate` to either script for a plain shape-only (version 1)
+  template, same as before this feature existed.
+
+Version 1 files (and version-1-shaped entries in a mixed file) are
+unaffected — `has_gate` is simply false for them, so they classify exactly
+as they did before. Cross-validated end to end: `features.py` produces
+identical numbers to the C implementation across several hand-built and
+random test frames, and a version-2 file written by `templates_format.py`
+loads correctly (gate ranges included) through the actual cross-compiled
+`templates_load()`/`classify()`.
+
+**Status:** this whole feature-gate mechanism is a separate, more
+experimental layer on top of the already-experimental base classifier — not
+yet tuned against real captured signals, and the default margins above are
+starting points, not calibrated values.
+
 ## File format
 
 See the docstring at the top of `templates_format.py` — kept in lockstep

--- a/tools/classifier_templates/capture_from_device.py
+++ b/tools/classifier_templates/capture_from_device.py
@@ -11,6 +11,17 @@ path for a first hardware smoke test; build out a proper synthesis-based
 template library (see synthesize_template.py) once the basic pipeline
 is confirmed working end to end.
 
+By default this also writes a version-2 feature gate (see templates_format.py
+and app/classifier/classifier.c's template_gate_factor()): each of the
+captured frames (not just their average) is run through the same
+bandwidth/PAPR/flatness/peak-count features the on-device daemon computes,
+and the range across those per-frame values -- widened a bit further by
+--gate-margin -- becomes the template's expected range. That's genuinely
+data-driven (actual capture-to-capture spread), unlike
+synthesize_template.py's single-idealized-curve range, so the default
+margin here is smaller. Pass --no-gate for a plain shape-only (version 1)
+template.
+
 Usage:
     python3 capture_from_device.py --host 192.168.1.50 --label OFDM \
         --template-id 1 --frames 20 --out templates.bin
@@ -22,7 +33,8 @@ import asyncio
 import struct
 import sys
 
-from templates_format import Template, normalize, write_templates, read_templates
+from features import extract_frame_features
+from templates_format import FeatureRanges, Template, normalize, write_templates, read_templates
 
 try:
     import websockets
@@ -58,6 +70,23 @@ def average_frames(frames):
     return [sum(f[i] for f in frames) / len(frames) for i in range(n)]
 
 
+def feature_ranges_from_frames(frames, margin: float) -> "FeatureRanges | None":
+    """Per-frame (not averaged) features across the actual capture, widened
+    by `margin` -- real observed spread, not a guess. Returns None if none
+    of the captured frames had enough energy to produce valid features."""
+    per_frame = [extract_frame_features(f) for f in frames]
+    valid = [ff for ff in per_frame if ff.valid]
+    if not valid:
+        return None
+    return FeatureRanges.from_samples(
+        [ff.bandwidth_frac for ff in valid],
+        [ff.papr_db for ff in valid],
+        [ff.flatness for ff in valid],
+        [ff.peak_count for ff in valid],
+        margin=margin,
+    )
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--host", required=True, help="device IP/hostname")
@@ -65,6 +94,11 @@ def main():
     ap.add_argument("--label", required=True, help="class label for this template (e.g. OFDM)")
     ap.add_argument("--template-id", type=int, required=True, help="numeric template id, must be unique within the output file")
     ap.add_argument("--frames", type=int, default=20, help="frames to capture and average (default: 20)")
+    ap.add_argument("--gate-margin", type=float, default=0.15,
+                     help="fractional margin further widening the observed per-frame feature "
+                          "spread into the template's expected range (default: 0.15)")
+    ap.add_argument("--no-gate", action="store_true",
+                     help="write a plain shape-only (version 1) template, with no feature gate")
     ap.add_argument("--out", required=True, help="templates.bin path to write/append to")
     args = ap.parse_args()
 
@@ -78,7 +112,15 @@ def main():
     canonical_n = len(avg)
     print(f"Captured and averaged {len(frames)} frames, {canonical_n} bins each.", file=sys.stderr)
 
-    new_template = Template(label=args.label, template_id=args.template_id, data=normalize(avg))
+    feature_ranges = None
+    if not args.no_gate:
+        feature_ranges = feature_ranges_from_frames(frames, args.gate_margin)
+        if feature_ranges is None:
+            print("warning: no captured frame had enough energy to compute a feature gate "
+                  "-- writing a shape-only template instead", file=sys.stderr)
+
+    new_template = Template(label=args.label, template_id=args.template_id,
+                             data=normalize(avg), feature_ranges=feature_ranges)
 
     # Append to an existing file if present (and its canonical_n matches),
     # otherwise start a fresh one — makes it natural to build a template
@@ -100,7 +142,8 @@ def main():
         templates = [new_template]
 
     write_templates(args.out, canonical_n, templates)
-    print(f"Wrote {len(templates)} template(s) to {args.out}.", file=sys.stderr)
+    gate_note = "with feature gate" if feature_ranges else "shape-only, no gate"
+    print(f"Wrote {len(templates)} template(s) to {args.out} ({gate_note}).", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tools/classifier_templates/features.py
+++ b/tools/classifier_templates/features.py
@@ -1,0 +1,78 @@
+"""features.py — the same four per-frame scalar features the on-device
+classifier computes, ported to Python so the offline tools can compute a
+version-2 template's expected feature ranges.
+
+Kept in lockstep with extract_frame_features() in app/classifier/classifier.c
+— same constants, same math, operating on the same input (raw linear
+amplitude, *not* the zero-mean/unit-L2-norm shape used for the correlation
+score itself). If you change one side, change the other.
+"""
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+# Must match app/classifier/classifier.c's BW_GATE_RATIO / PEAK_PROMINENCE_RATIO.
+BW_GATE_RATIO = 0.1          # -10 dB
+PEAK_PROMINENCE_RATIO = 0.0316227766016838  # -15 dB, i.e. 10**(-15/10)
+
+
+@dataclass
+class FrameFeatures:
+    valid: bool
+    bandwidth_frac: float
+    papr_db: float
+    flatness: float
+    peak_count: int
+    peak_bin: int
+
+
+def extract_frame_features(raw: Sequence[float]) -> FrameFeatures:
+    """`raw` is linear amplitude (not power, not dB, not normalized) —
+    exactly what classifier.c's extract_frame_features() takes."""
+    n = len(raw)
+    if n == 0:
+        return FrameFeatures(False, 0.0, 0.0, 0.0, 0, 0)
+
+    amps = [v if v > 0 else 0.0 for v in raw]
+    powers = [a * a for a in amps]
+    peak_i = max(range(n), key=lambda i: amps[i])
+    peak_amp = amps[peak_i]
+    sum_power = sum(powers)
+
+    if peak_amp <= 0.0 or sum_power <= 0.0:
+        return FrameFeatures(False, 0.0, 0.0, 0.0, 0, 0)
+
+    peak_power = peak_amp * peak_amp
+    mean_power = sum_power / n
+
+    papr_db = 10.0 * math.log10(peak_power / max(mean_power, 1e-20))
+
+    log_powers = [math.log(max(p, 1e-20)) for p in powers]
+    geomean_power = math.exp(sum(log_powers) / n)
+    flatness = min(geomean_power / max(mean_power, 1e-20), 1.0)
+
+    bw_gate = peak_power * BW_GATE_RATIO
+    lo, hi = peak_i, peak_i
+    while lo > 0 and powers[lo - 1] >= bw_gate:
+        lo -= 1
+    while hi + 1 < n and powers[hi + 1] >= bw_gate:
+        hi += 1
+    bandwidth_frac = (hi - lo + 1) / n
+
+    prom_gate = peak_power * PEAK_PROMINENCE_RATIO
+    min_sep = max(1, n // 64)
+    count = 0
+    last_peak = 0
+    have_last = False
+    for i in range(1, n - 1):
+        if powers[i] < prom_gate:
+            continue
+        if amps[i] <= amps[i - 1] or amps[i] <= amps[i + 1]:
+            continue
+        if have_last and (i - last_peak) < min_sep:
+            continue
+        count += 1
+        last_peak = i
+        have_last = True
+
+    return FrameFeatures(True, bandwidth_frac, papr_db, flatness, count, peak_i)

--- a/tools/classifier_templates/synthesize_template.py
+++ b/tools/classifier_templates/synthesize_template.py
@@ -17,6 +17,14 @@ GNU Radio/TorchSig synthesis pipeline (varied bandwidth, symbol rate,
 roll-off, realistic noise) for a production template library. Prefer
 capture_from_device.py against a real signal when you can.
 
+By default this also writes a version-2 feature gate (see templates_format.py
+and app/classifier/classifier.c's template_gate_factor()), computed from the
+synthesized shape's own bandwidth/PAPR/flatness/peak-count and widened by
+--gate-margin -- a generous default (0.25) since it's built from one
+idealized curve, not several real captures like capture_from_device.py's
+data-driven range. Pass --no-gate for a plain shape-only (version 1)
+template.
+
 Usage:
     python3 synthesize_template.py --shape ofdm --label LTE --template-id 3 \
         --bins 512 --bw-frac 0.4 --out templates.bin
@@ -25,7 +33,8 @@ import argparse
 
 import numpy as np
 
-from templates_format import Template, normalize, write_templates, read_templates
+from features import extract_frame_features
+from templates_format import FeatureRanges, Template, normalize, write_templates, read_templates
 
 SHAPES = ["ofdm", "narrowband", "chirp", "pulsed", "cw"]
 
@@ -110,6 +119,12 @@ def main():
     ap.add_argument("--bins", type=int, default=512, help="canonical_n (default: 512)")
     ap.add_argument("--bw-frac", type=float, default=0.3,
                      help="occupied bandwidth as a fraction of the template's span, 0-1 (default: 0.3)")
+    ap.add_argument("--gate-margin", type=float, default=0.25,
+                     help="fractional margin widening this shape's own computed features into an "
+                          "expected range for match gating (default: 0.25) -- generous, since it's "
+                          "built from one idealized curve rather than several real captures")
+    ap.add_argument("--no-gate", action="store_true",
+                     help="write a plain shape-only (version 1) template, with no feature gate")
     ap.add_argument("--out", required=True)
     args = ap.parse_args()
 
@@ -117,7 +132,18 @@ def main():
         raise SystemExit("--bw-frac must be in (0, 1]")
 
     raw = SYNTH[args.shape](args.bins, args.bw_frac)
-    new_template = Template(label=args.label, template_id=args.template_id, data=normalize(list(raw)))
+
+    feature_ranges = None
+    if not args.no_gate:
+        ff = extract_frame_features(list(raw))
+        if ff.valid:
+            feature_ranges = FeatureRanges.from_samples(
+                [ff.bandwidth_frac], [ff.papr_db], [ff.flatness], [ff.peak_count],
+                margin=args.gate_margin,
+            )
+
+    new_template = Template(label=args.label, template_id=args.template_id,
+                             data=normalize(list(raw)), feature_ranges=feature_ranges)
 
     try:
         existing_n, existing = read_templates(args.out)
@@ -132,7 +158,9 @@ def main():
         templates = [new_template]
 
     write_templates(args.out, args.bins, templates)
-    print(f"Wrote {len(templates)} template(s) to {args.out} (added/updated: {args.label!r}, shape={args.shape}).")
+    gate_note = "with feature gate" if feature_ranges else "shape-only, no gate"
+    print(f"Wrote {len(templates)} template(s) to {args.out} "
+          f"(added/updated: {args.label!r}, shape={args.shape}, {gate_note}).")
 
 
 if __name__ == "__main__":

--- a/tools/classifier_templates/templates_format.py
+++ b/tools/classifier_templates/templates_format.py
@@ -4,26 +4,78 @@ This is the dev-machine counterpart to app/classifier/classifier.c's
 templates_load(). Keep the two in sync — the format is:
 
     char     magic[4]      = b"SCFT"
-    uint32_t version       = 1
+    uint32_t version       = 1 or 2
     uint32_t count
     uint32_t canonical_n
     then `count` entries of:
         char     label[32]   (UTF-8, NUL-padded/truncated)
         uint32_t template_id
         float32  data[canonical_n]   (little-endian)
+        -- version 2 only, appended per entry --
+        float32  bandwidth_frac_lo, bandwidth_frac_hi
+        float32  papr_db_lo,        papr_db_hi
+        float32  flatness_lo,       flatness_hi
+        float32  peak_count_lo,     peak_count_hi
+
+A version-2 range with hi < lo means "unbounded" (no gate on that
+feature) — see FeatureRanges.UNBOUNDED below. Version 1 files behave as
+if every range were unbounded: the on-device classifier applies no gate
+to them, so old templates.bin files keep classifying exactly as before.
 
 Templates must already be normalized (zero-mean, unit L2 norm) before
 writing — the on-device loader trusts the file as-is and does not
 re-normalize on load, only the *live* frame gets normalized at runtime.
 Use normalize() below before passing data to write_templates().
+
+The feature ranges (when present) are the same four scalars
+app/classifier/classifier.c computes per live frame — see features.py,
+kept in lockstep with the C implementation.
 """
 import struct
-from dataclasses import dataclass
-from typing import Sequence
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
 
 MAGIC = b"SCFT"
-VERSION = 1
+VERSION_1 = 1
+VERSION_2 = 2
 LABEL_LEN = 32
+
+# hi < lo signals "no gate on this feature" to the on-device loader.
+_UNBOUNDED = (1.0, -1.0)
+
+
+@dataclass
+class FeatureRanges:
+    """Expected (lo, hi) range per feature, for a version-2 template's soft
+    match gate (see classifier.c's template_gate_factor()). Any field left
+    as UNBOUNDED is not gated. Construct these via from_features() below
+    rather than by hand in normal use."""
+    bandwidth_frac: tuple = _UNBOUNDED
+    papr_db: tuple = _UNBOUNDED
+    flatness: tuple = _UNBOUNDED
+    peak_count: tuple = _UNBOUNDED
+
+    UNBOUNDED = _UNBOUNDED
+
+    @staticmethod
+    def from_samples(bandwidth_fracs, papr_dbs, flatnesses, peak_counts, margin: float = 0.15):
+        """Build a FeatureRanges from one or more observed samples of each
+        feature (e.g. per-frame values from several captures, or a single
+        synthesized template's own computed features), widened by `margin`
+        as a fraction of the observed spread (or of the value itself, for a
+        single sample) so a range built from a handful of samples isn't
+        pathologically tight."""
+        def widen(values):
+            lo, hi = min(values), max(values)
+            pad = (hi - lo) * margin if hi > lo else max(abs(lo), 1e-6) * margin
+            return (lo - pad, hi + pad)
+
+        return FeatureRanges(
+            bandwidth_frac=widen(bandwidth_fracs),
+            papr_db=widen(papr_dbs),
+            flatness=widen(flatnesses),
+            peak_count=widen(peak_counts),
+        )
 
 
 @dataclass
@@ -31,6 +83,7 @@ class Template:
     label: str
     template_id: int
     data: Sequence[float]  # length must equal canonical_n for the file
+    feature_ranges: Optional[FeatureRanges] = field(default=None)
 
 
 def normalize(data: Sequence[float]) -> list:
@@ -58,9 +111,15 @@ def write_templates(path: str, canonical_n: int, templates: Sequence[Template]) 
             raise ValueError(
                 f"template {t.label!r} has {len(t.data)} samples, expected canonical_n={canonical_n}"
             )
+
+    # Version 2 only if at least one template actually carries ranges —
+    # otherwise stay on version 1 so a plain shape-only library round-trips
+    # through unmodified older tooling/devices exactly as it always has.
+    version = VERSION_2 if any(t.feature_ranges is not None for t in templates) else VERSION_1
+
     with open(path, "wb") as f:
         f.write(MAGIC)
-        f.write(struct.pack("<I", VERSION))
+        f.write(struct.pack("<I", version))
         f.write(struct.pack("<I", len(templates)))
         f.write(struct.pack("<I", canonical_n))
         for t in templates:
@@ -68,6 +127,10 @@ def write_templates(path: str, canonical_n: int, templates: Sequence[Template]) 
             f.write(label_bytes.ljust(LABEL_LEN, b"\x00"))
             f.write(struct.pack("<I", t.template_id))
             f.write(struct.pack(f"<{canonical_n}f", *t.data))
+            if version == VERSION_2:
+                fr = t.feature_ranges or FeatureRanges()
+                for lo, hi in (fr.bandwidth_frac, fr.papr_db, fr.flatness, fr.peak_count):
+                    f.write(struct.pack("<ff", lo, hi))
 
 
 def read_templates(path: str):
@@ -79,7 +142,7 @@ def read_templates(path: str):
         if magic != MAGIC:
             raise ValueError(f"bad magic {magic!r}, expected {MAGIC!r}")
         (version,) = struct.unpack("<I", f.read(4))
-        if version != VERSION:
+        if version not in (VERSION_1, VERSION_2):
             raise ValueError(f"unsupported version {version}")
         (count,) = struct.unpack("<I", f.read(4))
         (canonical_n,) = struct.unpack("<I", f.read(4))
@@ -89,5 +152,13 @@ def read_templates(path: str):
             label = label_bytes.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
             (template_id,) = struct.unpack("<I", f.read(4))
             data = struct.unpack(f"<{canonical_n}f", f.read(4 * canonical_n))
-            templates.append(Template(label=label, template_id=template_id, data=list(data)))
+            feature_ranges = None
+            if version == VERSION_2:
+                ranges = []
+                for _ in range(4):
+                    lo, hi = struct.unpack("<ff", f.read(8))
+                    ranges.append((lo, hi))
+                feature_ranges = FeatureRanges(*ranges)
+            templates.append(Template(label=label, template_id=template_id, data=list(data),
+                                       feature_ranges=feature_ranges))
         return canonical_n, templates


### PR DESCRIPTION
## ⚠️ Stacked on #433

This branch is built on top of #433 (the classifier display/blinking fixes and doc pass) — until #433 merges, this PR's diff includes that too. Same situation #427 called out for #426, flagging it upfront for the same reason.

## What this adds

Extends the shape-only classifier from #427/#433 with richer per-frame signal features and cross-cycle tracking, per a request to see "more features of the signal" — and lets those features actually gate the match, not just get displayed.

**Two real ceilings this addresses**, both visible in the code as merged:
1. **One frame, no memory.** Every classify cycle is evaluated from scratch — anything defined by behavior *over time* (most concretely a **chirp**, whose whole identity is a frequency sweep) can't be seen from a single frame. `tools/classifier_templates/synthesize_template.py` already documents its `chirp` shape as a static idealization for exactly this reason.
2. **Shape-only scoring.** Two classes with a similar envelope but different real bandwidth/peakiness were only told apart by curve-fit — nothing about absolute bandwidth, peakiness, or carrier count fed into the decision.

**`app/classifier/classifier.c`:**
- `extract_frame_features()`: four scalar features per live frame (-10dB occupied bandwidth, peak-to-average ratio, spectral flatness, local peak count), published every cycle over new `state/classifier/feature_*` MQTT topics regardless of match outcome.
- A small rolling history (16 cycles, ~16s) reduced each cycle into two cross-cycle features: peak-bin **drift** (an OLS slope — the actual chirp signature) and **duty cycle** (catches bursty/pulsed emitters). Both report "n/a" until there's enough history.
- `templates.bin` **version 2**: a template can declare an expected range per feature; `classify()` applies it as a *soft* penalty on the shape score (not a hard reject — real-world noise sits right at a boundary). Version 1 files are completely unaffected.

**`tools/classifier_templates/`:**
- New `features.py`, the same four features ported to Python, cross-validated to produce identical output to the real C implementation.
- `synthesize_template.py` / `capture_from_device.py` now compute a template's expected feature range automatically (from the synthesized curve's own features, or from the spread across captured frames, respectively) — `--no-gate` opts out for a plain version-1 template.

**`Dashboard/`:** a new always-visible "Signal Features" card (explicitly marked experimental) showing bandwidth/PAPR/flatness/peak-count/drift/duty-cycle, independent of match state.

## Status

**Experimental / work in progress**, layered on top of the already-experimental base classifier. Not yet run against real captured signals.

## Validation

No ARM cross-toolchain or real hardware available in this environment:
- C changes: `-Wall -Wextra -Wshadow` clean against the real `libwebsockets.h`, plus a standalone native unit-test harness (31 cases — feature extraction against constructed inputs with known expected values, gate penalty/floor behavior, history drift/duty-cycle math including ring-buffer wraparound, v1/v2 `templates.bin` load, and an end-to-end gating test where two identically-shaped templates are disambiguated purely by a bandwidth gate).
- Python tooling: `features.py` cross-validated against the real C `extract_frame_features()` (identical output across CW/OFDM/two-tone/silence/random-noise/edge cases), and a v2 `templates.bin` written by `templates_format.py` round-trips correctly through the actual cross-compiled `templates_load()`.
- Dashboard JS: no node/esbuild toolchain available here to run the JSX-parse check #427 used — checked by eye and with a brace/paren balance pass instead, flagged rather than claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)