### PR TITLE
iio_ws_proxy: CS12 pack, RX1-only, lazy device hold + DDC routing toggle

### DIFF
--- a/app/iio_ws/iio_ws_proxy.c
+++ b/app/iio_ws/iio_ws_proxy.c
@@ -162,6 +162,10 @@ struct app {
     bool         do_tx;
     bool         stats;
     bool         loop;
+    bool         do_cs12;    /* -C: pack RX int16 -> 12-bit (3 bytes/complex), ~25% less link BW */
+    bool         rx1_only;   /* -1: enable only RX1 (first 2 scan elements) for a clean I/Q stream */
+    bool         lazy;       /* -L: hold cf-ad9361-lpc only while an RX WS client is connected */
+    atomic_bool  want_rx;    /* lazy: an iio-rx client is currently connected */
 
     /* IIO */
     struct iio_context *iio;
@@ -209,13 +213,39 @@ static struct app A;
 /* ------------------------------------------------------------------ */
 /* IIO helpers                                                         */
 /* ------------------------------------------------------------------ */
-static void enable_channels(struct iio_device *dev)
+/* Pack S12/16 int16 IQ -> tight 12-bit, 3 bytes per complex (2 int16). ~25% less
+ * link bandwidth. Byte order matches the OpenRF MaiaSource host decoder. */
+static size_t pack_cs12(uint8_t *restrict dst, const int16_t *restrict src, size_t n_int16)
+{
+    size_t o = 0;
+    for (size_t i = 0; i + 1 < n_int16; i += 2) {
+        uint16_t v0 = (uint16_t)src[i]     & 0x0FFF;
+        uint16_t v1 = (uint16_t)src[i + 1] & 0x0FFF;
+        dst[o++] = (uint8_t)(v0 & 0xFF);
+        dst[o++] = (uint8_t)(((v1 & 0x0F) << 4) | ((v0 >> 8) & 0x0F));
+        dst[o++] = (uint8_t)((v1 >> 4) & 0xFF);
+    }
+    return o;
+}
+
+/* Enable scan-element channels. max_scan>0 limits to the first max_scan scan
+ * elements (RX1-only = 2: voltage0=I, voltage1=Q); 0 = all. The AD9361 exposes
+ * 4 RX scan elements (RX1 I/Q + RX2 I/Q); enabling all packs 8-byte slots that a
+ * single-RX consumer misreads, so RX1-only gives a clean 4-byte interleaved stream. */
+static void enable_channels(struct iio_device *dev, unsigned max_scan)
 {
     unsigned n = iio_device_get_channels_count(dev);
+    unsigned en = 0;
     for (unsigned i = 0; i < n; i++) {
         struct iio_channel *ch = iio_device_get_channel(dev, i);
-        if (iio_channel_is_scan_element(ch))
-            iio_channel_enable(ch);
+        if (iio_channel_is_scan_element(ch)) {
+            if (max_scan && en >= max_scan) {
+                iio_channel_disable(ch);
+            } else {
+                iio_channel_enable(ch);
+                en++;
+            }
+        }
     }
 }
 
@@ -259,12 +289,41 @@ static void *rx_thread(void *arg)
     struct app *a = arg;
 
     while (a->running) {
+        /* Lazy device hold: own cf-ad9361-lpc only while an RX client is connected,
+         * so ordinary libiio clients (SDR++/SDR#) can use the device when idle. All
+         * rx_buf create/destroy stays in this one thread to avoid cross-thread races. */
+        if (a->lazy) {
+            bool want = atomic_load_explicit(&a->want_rx, memory_order_acquire);
+            if (want && !a->rx_buf) {
+                enable_channels(a->rx_dev, a->rx1_only ? 2 : 0);
+                a->rx_buf = iio_device_create_buffer(a->rx_dev, a->buf_samples, false);
+                if (!a->rx_buf) { usleep(50000); continue; }
+                fprintf(stderr, "[rx] client present -> acquired %s\n", a->rx_dev_name);
+            } else if (!want && a->rx_buf) {
+                struct iio_buffer *b = a->rx_buf;
+                a->rx_buf = NULL;
+                iio_buffer_destroy(b);
+                fprintf(stderr, "[rx] no client -> released %s\n", a->rx_dev_name);
+            }
+            if (!a->rx_buf) { usleep(20000); continue; }
+        }
+
         ssize_t nb = iio_buffer_refill(a->rx_buf);
         if (nb < 0) {
             if (!a->running) break;
             if (-nb == ETIMEDOUT) continue;
-            fprintf(stderr, "[rx] refill: %s\n", strerror(-nb));
-            break;
+            /* Survive a rate change / transient DMA error: drop the buffer and
+             * recreate it instead of dying, so the stream resumes by itself. */
+            fprintf(stderr, "[rx] refill: %s -> recreating buffer\n", strerror(-nb));
+            iio_buffer_destroy(a->rx_buf);
+            a->rx_buf = NULL;
+            if (!a->lazy) {
+                enable_channels(a->rx_dev, a->rx1_only ? 2 : 0);
+                a->rx_buf = iio_device_create_buffer(a->rx_dev, a->buf_samples, false);
+                if (!a->rx_buf) { fprintf(stderr, "[rx] recreate failed\n"); break; }
+            }
+            usleep(50000);
+            continue;
         }
 
         if (!atomic_load_explicit(&a->wsi_rx, memory_order_acquire))
@@ -276,14 +335,23 @@ static void *rx_thread(void *arg)
             continue;
         }
 
-        size_t bytes = (size_t)nb < a->rx_ring.cap ? (size_t)nb : a->rx_ring.cap;
-        memcpy_iio(sl->buf + LWS_PRE, iio_buffer_start(a->rx_buf), bytes);
+        size_t bytes;
+        if (a->do_cs12) {
+            /* nb bytes = nb/2 int16 samples -> nb*3/4 packed bytes (< raw, fits cap) */
+            bytes = pack_cs12(sl->buf + LWS_PRE,
+                              (const int16_t *)iio_buffer_start(a->rx_buf),
+                              (size_t)nb / sizeof(int16_t));
+        } else {
+            bytes = (size_t)nb < a->rx_ring.cap ? (size_t)nb : a->rx_ring.cap;
+            memcpy_iio(sl->buf + LWS_PRE, iio_buffer_start(a->rx_buf), bytes);
+        }
         sl->len = bytes;
         ring_write_end(&a->rx_ring);
 
         atomic_fetch_add_explicit(&a->rx_bytes, bytes, memory_order_relaxed);
         lws_cancel_service(a->lws);
     }
+    if (a->lazy && a->rx_buf) { iio_buffer_destroy(a->rx_buf); a->rx_buf = NULL; }
     return NULL;
 }
 
@@ -356,6 +424,8 @@ static int ws_cb(struct lws *wsi, enum lws_callback_reasons reason,
                     fprintf(stderr, "[ws] TCP_USER_TIMEOUT: %s\n", strerror(errno));
             }
             atomic_store_explicit(&A.wsi_rx, (uintptr_t)wsi, memory_order_release);
+            if (A.lazy)
+                atomic_store_explicit(&A.want_rx, true, memory_order_release);
         }
         if (is_tx) {
             struct lws *ex = (struct lws *)atomic_load_explicit(&A.wsi_tx, memory_order_acquire);
@@ -379,6 +449,8 @@ static int ws_cb(struct lws *wsi, enum lws_callback_reasons reason,
     case LWS_CALLBACK_CLOSED:
         if (atomic_load_explicit(&A.wsi_rx, memory_order_acquire) == (uintptr_t)wsi) {
             atomic_store_explicit(&A.wsi_rx, (uintptr_t)NULL, memory_order_release);
+            if (A.lazy)
+                atomic_store_explicit(&A.want_rx, false, memory_order_release);
             fprintf(stderr, "[ws] RX client disconnected\n");
         }
         if (atomic_load_explicit(&A.wsi_tx, memory_order_acquire) == (uintptr_t)wsi) {
@@ -502,6 +574,9 @@ static void usage(const char *prog)
         "  -c CERT   TLS certificate (default: %s)\n"
         "  -k KEY    TLS private key (default: %s)\n"
         "  -P PORT   WSS port, opened only if CERT/KEY are readable (default: %d)\n"
+        "  -C        pack RX as CS12 (12-bit, 3 bytes/complex)\n"
+        "  -1        RX1 only (first 2 scan elements: clean 4-byte I/Q)\n"
+        "  -L        lazy device hold (own RX device only while a WS client is connected)\n"
         "  -h        this help\n",
         prog,
         DEF_IIO_URI, DEF_RX_DEV, DEF_TX_DEV,
@@ -539,7 +614,7 @@ int main(int argc, char **argv)
     A.loop        = false;
 
     int opt;
-    while ((opt = getopt(argc, argv, "u:r:t:p:n:c:k:P:RTslh")) != -1) {
+    while ((opt = getopt(argc, argv, "u:r:t:p:n:c:k:P:RTsl1LCh")) != -1) {
         switch (opt) {
         case 'u': A.iio_uri     = optarg;           break;
         case 'r': A.rx_dev_name = optarg;           break;
@@ -553,6 +628,9 @@ int main(int argc, char **argv)
         case 'T': A.do_rx = false; A.do_tx = true;  break;
         case 's': A.stats = true;                   break;
         case 'l': A.loop  = true;                   break;
+        case 'C': A.do_cs12  = true;                break;
+        case '1': A.rx1_only = true;                break;
+        case 'L': A.lazy     = true;                break;
         case 'h': usage(argv[0]); return 0;
         default:  usage(argv[0]); return 1;
         }
@@ -574,14 +652,21 @@ int main(int argc, char **argv)
             fprintf(stderr, "device not found: %s\n", A.rx_dev_name);
             return 1;
         }
-        enable_channels(A.rx_dev);
+        enable_channels(A.rx_dev, A.rx1_only ? 2 : 0);
         iio_device_set_kernel_buffers_count(A.rx_dev, 8);
         A.sample_size = iio_device_get_sample_size(A.rx_dev);
         A.buf_bytes   = A.buf_samples * A.sample_size;
-        A.rx_buf = iio_device_create_buffer(A.rx_dev, A.buf_samples, A.loop);
-        if (!A.rx_buf) { fprintf(stderr, "rx buffer create failed\n"); return 1; }
-        fprintf(stderr, "iio: RX dev=%s  samples=%zu  sample_size=%zu  buf=%zu B\n",
-                A.rx_dev_name, A.buf_samples, A.sample_size, A.buf_bytes);
+        if (A.lazy) {
+            /* Defer buffer creation to the RX thread (created on first WS client),
+             * so the device stays free for ordinary libiio clients while idle. */
+            fprintf(stderr, "iio: RX dev=%s  lazy-hold (acquired on WS connect)  sample_size=%zu\n",
+                    A.rx_dev_name, A.sample_size);
+        } else {
+            A.rx_buf = iio_device_create_buffer(A.rx_dev, A.buf_samples, A.loop);
+            if (!A.rx_buf) { fprintf(stderr, "rx buffer create failed\n"); return 1; }
+            fprintf(stderr, "iio: RX dev=%s  samples=%zu  sample_size=%zu  buf=%zu B\n",
+                    A.rx_dev_name, A.buf_samples, A.sample_size, A.buf_bytes);
+        }
     }
 
     if (A.do_tx) {
@@ -590,7 +675,7 @@ int main(int argc, char **argv)
             fprintf(stderr, "device not found: %s\n", A.tx_dev_name);
             return 1;
         }
-        enable_channels(A.tx_dev);
+        enable_channels(A.tx_dev, 0);
         iio_device_set_kernel_buffers_count(A.tx_dev, 4);
         if (!A.sample_size) {
             A.sample_size = iio_device_get_sample_size(A.tx_dev);
@@ -673,6 +758,7 @@ int main(int argc, char **argv)
     A.running = true;
     atomic_init(&A.wsi_rx, (uintptr_t)NULL);
     atomic_init(&A.wsi_tx, (uintptr_t)NULL);
+    atomic_init(&A.want_rx, false);
     if (A.do_rx) { pthread_create(&A.rx_tid, NULL, rx_thread, &A); set_realtime(A.rx_tid, 10); }
     if (A.do_tx) { pthread_create(&A.tx_tid, NULL, tx_thread, &A); set_realtime(A.tx_tid,  5); }
 

--- a/board/tezuka/common/overlay_tezuka/root/firdecim.sh
+++ b/board/tezuka/common/overlay_tezuka/root/firdecim.sh
@@ -1,5 +1,29 @@
 #!/bin/sh
+# Manual DDC helper: design the decimating FIR and route the DDC output into the
+# cf-ad9361-lpc capture device, both via maia-httpd REST on port 80.
+#
+#   firdecim.sh <decimation> [on|off]
+#     on  (default) : design FIR for <decimation> and enable DDC routing
+#     off           : restore full-rate wideband IQ (disable routing)
+#
+# Routing is default-OFF at boot (nothing sets it), so ordinary libiio clients
+# (SDR++/SDR#/GNU Radio) get full IQ until this (or an API client like OpenRF)
+# enables it. Previously this PUT a dead :8000 and poked devmem 0x790200BC directly;
+# it now goes through PATCH /api/ddc/config {enabled} so the state stays consistent.
 decim=$1
-curl -X PUT -H "Content-Type: application/json" -d '{"frequency":0.0,"decimation":'"$decim"',"transition_bandwidth":0.05,"passband_ripple":0.01,"stopband_attenuation_db":60.0,"stopband_one_over_f":true}' "http://localhost:8000/api/ddc/design"
+state=${2:-on}
+api="http://localhost:80/api"
 
-devmem 0x790200BC 32 1
+if [ -z "$decim" ]; then
+  echo "usage: $0 <decimation> [on|off]" >&2
+  exit 1
+fi
+
+curl -fsS -X PUT -H "Content-Type: application/json" \
+  -d '{"frequency":0.0,"decimation":'"$decim"',"transition_bandwidth":0.05,"passband_ripple":0.01,"stopband_attenuation_db":60.0,"stopband_one_over_f":true}' \
+  "$api/ddc/design"
+
+if [ "$state" = "off" ]; then en=false; else en=true; fi
+curl -fsS -X PATCH -H "Content-Type: application/json" \
+  -d '{"enabled":'"$en"'}' \
+  "$api/ddc/config"

--- a/package/maia-httpd/0001-ddc-routing-toggle.patch
+++ b/package/maia-httpd/0001-ddc-routing-toggle.patch
@@ -1,0 +1,84 @@
+Add DDC routing toggle to PATCH /api/ddc/config (axi_ad9361 reg 0x790200BC)
+
+OpenRF MaiaSource needs to route the on-FPGA DDC output into cf-ad9361-lpc
+for its overlay session and restore full-rate IQ afterwards, so ordinary
+libiio clients (SDR++/SDR#/GNU Radio) keep wideband IQ by default. The
+routing register lives in the cf-ad9361-lpc core (outside the maia-sdr UIO
+region) so it is written via a one-shot /dev/mem mapping. Adds a settable
+'enabled' field to PatchDDCConfig; None leaves routing unchanged.
+
+Signed-off-by: The OpenRF Authors <noreply@openrf>
+
+--- a/maia-httpd/maia-json/src/lib.rs	2026-06-24 19:04:42.873218045 +0200
++++ b/maia-httpd/maia-json/src/lib.rs	2026-06-24 19:04:59.976374262 +0200
+@@ -366,6 +366,13 @@
+     /// Frequency for the mixer, in Hz.
+     #[serde(skip_serializing_if = "Option::is_none")]
+     pub frequency: Option<f64>,
++    /// Whether to route the DDC output into the cf-ad9361-lpc capture device.
++    ///
++    /// `Some(true)` enables DDC routing (the iio capture carries the decimated
++    /// narrow channel); `Some(false)` restores full-rate wideband IQ; `None`
++    /// leaves routing unchanged. Maps to axi_ad9361 register 0x790200BC.
++    #[serde(skip_serializing_if = "Option::is_none")]
++    pub enabled: Option<bool>,
+ }
+ 
+ /// Configuration of a FIR filter in the DDC.
+--- a/maia-httpd/src/httpd/ddc.rs	2026-06-24 19:04:42.875218064 +0200
++++ b/maia-httpd/src/httpd/ddc.rs	2026-06-24 19:05:23.683589665 +0200
+@@ -4,6 +4,44 @@
+ use axum::{Json, extract::State};
+ use maia_json::{DDCConfig, DDCConfigSummary, PatchDDCConfig, PutDDCConfig, PutDDCDesign};
+ 
++/// Route the on-FPGA DDC output into the cf-ad9361-lpc capture device, or restore
++/// full-rate wideband IQ, by writing the axi_ad9361 routing register 0x790200BC.
++///
++/// This register lives in the cf-ad9361-lpc core (not the maia-sdr UIO region), so
++/// it is written through a one-shot /dev/mem mapping. The boot/default state is
++/// disabled, so ordinary libiio clients (SDR++/SDR#/GNU Radio) stream full-rate IQ
++/// unless a client (e.g. the OpenRF overlay) explicitly enables routing for its
++/// session and disables it again when done.
++fn set_ddc_routing(enable: bool) -> Result<()> {
++    use std::os::unix::io::AsRawFd;
++    const REG_BASE: libc::off_t = 0x7902_0000;
++    const REG_OFFSET: usize = 0xBC;
++    const MAP_LEN: usize = 0x1000;
++    let mem = std::fs::OpenOptions::new()
++        .read(true)
++        .write(true)
++        .open("/dev/mem")?;
++    // SAFETY: map one page at the page-aligned core base and write the 32-bit
++    // routing register at offset 0xBC with volatile semantics, then unmap.
++    unsafe {
++        let map = libc::mmap(
++            std::ptr::null_mut(),
++            MAP_LEN,
++            libc::PROT_READ | libc::PROT_WRITE,
++            libc::MAP_SHARED,
++            mem.as_raw_fd(),
++            REG_BASE,
++        );
++        if map == libc::MAP_FAILED {
++            anyhow::bail!("mmap /dev/mem for DDC routing register failed");
++        }
++        let reg = (map as *mut u8).add(REG_OFFSET) as *mut u32;
++        std::ptr::write_volatile(reg, u32::from(enable));
++        libc::munmap(map, MAP_LEN);
++    }
++    Ok(())
++}
++
+ async fn ddc_config(state: &AppState) -> Result<Json<DDCConfig>, JsonError> {
+     let samp_rate = state
+         .ad9361_samp_rate()
+@@ -62,6 +100,9 @@
+             .set_ddc_frequency(frequency, samp_rate)
+             .map_err(JsonError::client_error_alert)?;
+     }
++    if let Some(enabled) = patch.enabled {
++        set_ddc_routing(enabled).map_err(JsonError::server_error)?;
++    }
+     ddc_config(&state).await
+ }
+ 


### PR DESCRIPTION
Refresh of #367, rebased onto current `main` (that PR targeted `future`, which has not moved since July).

**Scoped down to the mutually useful parts, per your suggestion.** The OpenRF-specific service files
that were in #367 — `S70openrf` and `telem_pub.sh` — are **not** here; they will be installed by an
`openrf` package pulled from the OpenRF repo instead, so tezuka does not carry them.

What is left is three changes to your own components:

- **`iio_ws_proxy`** — opt-in CS12 packing (12-bit, 3 bytes/complex, ~25% less link bandwidth),
  RX1-only mode for a clean 4-byte I/Q stream, lazy device hold (own `cf-ad9361-lpc` only while a WS
  client is connected, so the device stays free for ordinary libiio clients while idle), and
  resilience across sample-rate changes.
- **`maia-httpd` patch** — a DDC routing enable toggle over REST.
- **`firdecim.sh`** — use REST on :80 and the DDC enable toggle.

### One thing worth reviewing

`-c` is now yours for the TLS certificate (added since #367), so **the CS12 flag moved to `-C`**.
Your `-l` cyclic-buffer option is preserved on the eager path, and the lazy path defers buffer
creation to the RX thread. Everything else in `iio_ws_proxy` is additive.

### DCO

All three commits are signed off with author and `Signed-off-by` matching
(`electro-logic <electro-logic@users.noreply.github.com>`), which is what the check was rejecting on
the old branch.

Not build-tested against a full buildroot here — the conflicts were resolved by hand against your
current tree, so a look at the `iio_ws_proxy` option handling in particular is welcome.
